### PR TITLE
Update XMP Toolkit submodule to August 2021 Release - try again for Github Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without 
 
+## Unreleased
+
+* Update XMP Toolkit submodule to August 2021 Release
+
 ## v0.1.8
 _23 June 2021_
 


### PR DESCRIPTION
## Changes in This Pull Request
Simply updating the XMP Toolkit submodule to the current (August 2021) Release.  
No changes to the Rust code itself.
For changes in the XMP Toolkit see https://github.com/adobe/XMP-Toolkit-SDK/releases/tag/v2021.08

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
