### PR TITLE
Bump MSRV to 1.46.0 due to new dependency from bitflags crae.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [1.44.0, 1.53.0]
+        rust_version: [1.46.0, 1.53.0]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without 
 
+## Unreleased (likely v0.2.0)
+_date_
+
+* Bumped MSRV to 1.46.0 due to new dependency from bitflags crate.
+
 ## v0.1.8
 _23 June 2021_
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contributions that ...
 
 ## Rust Language Support
 
-As of this writing, this crate requires **Rust version 1.44** or newer. (The CI builds use this version of Rust.) This may be increased to a newer version at any time, but will be noted in the changelog.
+As of this writing, this crate requires **Rust version 1.46** or newer. (The CI builds use this version of Rust.) This may be increased to a newer version at any time, but will be noted in the changelog.
 
 This crate follows all of the typical Rust conventions (`cargo build`, `cargo test`, etc.). There is a `build.rs` script which will ensure that the C++ portions of the library are built as needed. It may need to be updated for platforms that haven't already been tested.
 


### PR DESCRIPTION
New build issues have arisen since last PR on this project. Use this PR to debug and get back to a clean build.