### PR TITLE
Add Rust 1.56 to CI builds.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: 1.56.0
           override: true
 
       - name: Install clippy

--- a/.github/workflows/code-fmt.yml
+++ b/.github/workflows/code-fmt.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: 1.56.0
           override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [1.46.0, 1.55.0]
+        rust_version: [1.46.0, 1.56.0]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 ## Unreleased
 
-* Update XMP Toolkit submodule to October 2021 Release.
+* Add Rust 1.56.0 to CI build matrix. (#29)
+* Remove Rust 1.53.0 from CI build matrix.
+* Update XMP Toolkit submodule to October 2021 Release. (#28)
 
 ## v0.2.0
 _12 October 2021_


### PR DESCRIPTION
## Changes in This Pull Request
Change CI builds to use Rust 1.56 instead of 1.55.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
