### PR TITLE
Prepare 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 ## v0.3.4
 _28 April 2022_
 
-* Fix a packaging error that caused zlib v1.2.11 to still be used.
+* Fix a subtle bug in converting to modern function prototypes.
 
 ## v0.3.3
 _28 April 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
 
+## v0.3.4
+_28 April 2022_
+
+* Fix a packaging error that caused zlib v1.2.11 to still be used.
+
 ## v0.3.3
 _28 April 2022_
 
-* Update zlip to v1.2.12. (#38)
+* Update zlib to v1.2.12. (#38)
 * Add Rust 1.60.0 to CI build matrix.
 * Remove Rust 1.59.0 from CI build matrix.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmp_toolkit"
-version = "0.3.3"
+version = "0.3.4"
 description = "Rust-language bindings for Adobe's XMP Toolkit"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/adobe/xmp-toolkit-rs"

--- a/external/zlib/deflate.c
+++ b/external/zlib/deflate.c
@@ -565,9 +565,9 @@ int ZEXPORT deflateSetHeader (
 
 /* ========================================================================= */
 int ZEXPORT deflatePending (
+    z_streamp strm,
     unsigned *pending,
-    int *bits,
-    z_streamp strm)
+    int *bits)
 {
     if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
     if (pending != Z_NULL)


### PR DESCRIPTION
Fixes a subtle bug in my conversion to modern function prototypes.