### PR TITLE
Add convenience function for reading XMP from a file

### DIFF
--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -64,7 +64,7 @@ impl XmpMeta {
 
         f.open_file(path, OpenFileOptions::OPEN_ONLY_XMP)?;
 
-        Ok(f.xmp().unwrap_or_else(|| Self::new()))
+        Ok(f.xmp().unwrap_or_else(Self::new))
     }
 
     /// Registers a namespace URI with a suggested prefix.


### PR DESCRIPTION
## Changes in this pull request
Adds new API function `XmpMeta::from_file(path)`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
