### PR TITLE
Configure dependabot to watch dependencies brought in via git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,15 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
 updates:
+
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "external"
+    schedule:
+      interval: "daily"
+    # This may become too noisy if we start picking up untagged commits.
+    # Watch https://github.com/dependabot/dependabot-core/issues/1639.


### PR DESCRIPTION
Those are libexpat and the C++ XMP Toolkit.
