### PR TITLE
Require API docs for all public API surfaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 // each license.
 
 #![deny(warnings)]
+#![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
 
 mod ffi;
 


### PR DESCRIPTION
Related: Generate crate-level docs from README.
