### PR TITLE
Rework `OpenFileOptions` as an opaque type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ exclude = [
     "external/xmp_toolkit/XMPFilesPlugins/PDF_Handler",
 ]
 
-[dependencies]
-bitflags = "1.3"
-
 [build-dependencies]
 cc = "1.0"
 fs_extra = "1.2"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ xmp_toolkit = "0.3.8"
 
 The `xmp_const` module has been removed and a new `xmp_ns` module has been added, containing constants for many common XMP namespaces. Replace `xmp_const::XMP_NS_XMP` with `xmp_ns::XMP`.
 
+The `OpenFileOptions` mod has been reworked as an opaque type, removing the need for the bitflags crate dependency. Create by using `OpenFileOptions::default()` and then calling methods on the struct to add options as needed.
+
 ## License
 
 The `xmp_toolkit` crate is distributed under the terms of both the MIT license and the Apache License (Version 2.0).

--- a/src/xmp_file.rs
+++ b/src/xmp_file.rs
@@ -157,15 +157,9 @@ impl XmpFile {
 ///
 /// Invoke by calling [`OpenFileOptions::default()`] and then calling methods
 /// on this struct to add options as needed.
-
+#[derive(Default)]
 pub struct OpenFileOptions {
     pub(crate) options: u32,
-}
-
-impl Default for OpenFileOptions {
-    fn default() -> Self {
-        Self { options: 0 }
-    }
 }
 
 impl OpenFileOptions {

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -62,7 +62,7 @@ impl XmpMeta {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, XmpFileError> {
         let mut f = XmpFile::new();
 
-        f.open_file(path, OpenFileOptions::OPEN_ONLY_XMP)?;
+        f.open_file(path, OpenFileOptions::default().only_xmp())?;
 
         Ok(f.xmp().unwrap_or_else(Self::new))
     }


### PR DESCRIPTION
## Changes in this pull request

Create by using `OpenFileOptions::default()` and then calling methods on the struct to add options as needed.

This removes the need for the bitflags crate dependency.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
