### PR TITLE
Fix broken documentation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  doc_format:
+  docs_rs:
     name: Preflight docs.rs build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,26 +125,30 @@ jobs:
           args: --all -- --check
 
   doc_format:
-    name: Doc format
+    name: Preflight docs.rs build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       
-      - name: Install Rust toolchain
+      - name: Install nightly Rust toolchain
+        # Nightly is used here because the docs.rs build
+        # uses nightly and we use doc_cfg features that are
+        # not in stable Rust as of this writing (Rust 1.62).
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v1
-
       - name: Run cargo docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps
+        # This is intended to mimic the docs.rs build
+        # environment. The goal is to fail PR validation
+        # if the subsequent release would result in a failed
+        # documentation build on docs.rs.
+        run: cargo +nightly doc --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
+          DOCS_RS: 1
 
   cargo-deny:
     name: License / vulnerability audit
@@ -157,7 +161,7 @@ jobs:
           - advisories
           - bans licenses sources
 
-    # Prevent sudden announcement of a new advisory from failing ci:
+    # Prevent sudden announcement of a new advisory from failing CI:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,12 @@ use std::{env, ffi::OsStr, path::PathBuf};
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
+    println!("> git submodule init\n");
+    git_command(&["submodule", "init"]);
+
+    println!("> git submodule update\n");
+    git_command(&["submodule", "update"]);
+
     // docs.rs builds in an environment that doesn't allow us to modify
     // the underlying source. We don't actually need to fully compile,
     // so we do a specialized build that makes all the FFIs into no-ops.
@@ -27,12 +33,6 @@ fn main() {
     } else {
         eprintln!("INFO: building standard FFI for crate");
     }
-
-    println!("> git submodule init\n");
-    git_command(&["submodule", "init"]);
-
-    println!("> git submodule update\n");
-    git_command(&["submodule", "update"]);
 
     // Special note: Because of the post-processing we're doing here,
     // you must specify the `--no-verify` option when invoking `cargo publish`.

--- a/build.rs
+++ b/build.rs
@@ -21,8 +21,11 @@ fn main() {
     // so we do a specialized build that makes all the FFIs into no-ops.
     let docs_rs = env::var("DOCS_RS");
     if docs_rs == Ok("1".to_string()) {
+        eprintln!("INFO: building no-op FFI for docs.rs");
         compile_for_docs();
         return;
+    } else {
+        eprintln!("INFO: building standard FFI for crate");
     }
 
     println!("> git submodule init\n");

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -120,7 +120,9 @@ extern "C" {
         #endif
 
         CXmpFile() {
-            f.SetErrorCallback(xmpFileErrorCallback, &err, 0xffffffff);
+            #ifndef NOOP_FFI
+                f.SetErrorCallback(xmpFileErrorCallback, &err, 0xffffffff);
+            #endif
         }
     } CXmpFile;
 


### PR DESCRIPTION
## Changes in this pull request
Release 0.5.0 [failed to build on docs.rs](https://docs.rs/crate/xmp_toolkit/0.5.0) because the so-called "no-op" C++ code contained a reference to a field that was disabled elsewhere.

This PR fixes the unwanted field reference in the `NOOP_FFI` case and updates the PR validation loop to more closely mimic the docs.rs runtime environment so we detect future errors of this type.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
