### PR TITLE
Introduce new error type `XmpErrorType::NulInRustString`

### DIFF
--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -144,6 +144,23 @@ mod set_property {
         assert_eq!(err.error_type, XmpErrorType::BadXPath);
         assert_eq!(err.debug_message, "Empty property name");
     }
+
+    #[test]
+    fn error_nul_in_name() {
+        let mut m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+
+        XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
+
+        let err = m
+            .set_property("http://purl.org/dc/terms/", "x\0x", "blah")
+            .unwrap_err();
+
+        assert_eq!(err.error_type, XmpErrorType::NulInRustString);
+        assert_eq!(
+            err.debug_message,
+            "Unable to convert to C string because a NUL byte was found"
+        );
+    }
 }
 
 mod does_property_exist {
@@ -199,5 +216,21 @@ mod set_property_date {
 
         assert_eq!(err.error_type, XmpErrorType::BadSchema);
         assert_eq!(err.debug_message, "Empty schema namespace URI");
+    }
+
+    #[test]
+    fn error_nul_in_name() {
+        let mut m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        let updated_time = XmpDateTime::current().unwrap();
+
+        let err = m
+            .set_property_date("x\0x", "MetadataDate", &updated_time)
+            .unwrap_err();
+
+        assert_eq!(err.error_type, XmpErrorType::NulInRustString);
+        assert_eq!(
+            err.debug_message,
+            "Unable to convert to C string because a NUL byte was found"
+        );
     }
 }

--- a/src/xmp_error.rs
+++ b/src/xmp_error.rs
@@ -11,12 +11,15 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::{ffi::CStr, fmt};
-
-use num_enum::FromPrimitive;
-use thiserror::Error;
-
-use crate::ffi::CXmpError;
+use {
+    crate::ffi::CXmpError,
+    num_enum::FromPrimitive,
+    std::{
+        ffi::{CStr, NulError},
+        fmt,
+    },
+    thiserror::Error,
+};
 
 /// Describes error conditions returned by most XMP Toolkit operations.
 #[derive(Debug)]
@@ -47,6 +50,15 @@ impl XmpError {
             })
         } else {
             Ok(())
+        }
+    }
+}
+
+impl From<NulError> for XmpError {
+    fn from(_: NulError) -> Self {
+        XmpError {
+            error_type: XmpErrorType::NulInRustString,
+            debug_message: "Unable to convert to C string because a NUL byte was found".to_owned(),
         }
     }
 }
@@ -263,6 +275,11 @@ pub enum XmpErrorType {
     /// PNG format error.
     #[error("PNG format error")]
     BadPng = 213,
+
+    // --- Rust-specific errors ---
+    /// Can not convert from Rust string to C string because a NUL byte was found.
+    #[error("Unable to convert to C string because a NUL byte was found")]
+    NulInRustString = -432,
 }
 
 /// A specialized `Result` type for XMP Toolkit operations.

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -158,9 +158,9 @@ impl XmpMeta {
         prop_name: &str,
         prop_value: &str,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(schema_ns).unwrap();
-        let c_name = CString::new(prop_name).unwrap();
-        let c_value = CString::new(prop_value).unwrap();
+        let c_ns = CString::new(schema_ns)?;
+        let c_name = CString::new(prop_name)?;
+        let c_value = CString::new(prop_value)?;
         let mut err = ffi::CXmpError::default();
 
         unsafe {
@@ -196,8 +196,8 @@ impl XmpMeta {
         prop_name: &str,
         prop_value: &XmpDateTime,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(schema_ns).unwrap();
-        let c_name = CString::new(prop_name).unwrap();
+        let c_ns = CString::new(schema_ns)?;
+        let c_name = CString::new(prop_name)?;
         let mut err = ffi::CXmpError::default();
 
         unsafe {


### PR DESCRIPTION
## Changes in this pull request
Use this to remove some `.unwrap()` calls in `XmpMeta`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
