### PR TITLE
Fix unicode-ident to 1.0.1 until review of additional license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ exclude = [
     "external/xmp_toolkit/XMPFilesPlugins/PDF_Handler",
 ]
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["unicode-ident"] # remove when licnese has been reviewed
+
 [dependencies]
 num_enum = "0.5.7"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 [dependencies]
 num_enum = "0.5.7"
 thiserror = "1.0"
+unicode-ident = "=1.0.1" # need review of Unicode-DFS-2016 before updating to 1.0.2+
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
unicode-ident 1.0.2 (just released) added a new license. Need to review new license terms before updating.