### PR TITLE
(IGNORE) Make code formatting more consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: rustfmt
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,17 @@
+# IMPORTANT: PR validation uses nightly version of
+# rustfmt.
+
+# Invoke by using:
+#
+# rustup toolchain add nightly
+# cargo +nightly fmt
+
+blank_lines_upper_bound = 1
+empty_item_single_line = true
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+hex_literal_case = "Lower"
+imports_granularity = "Crate"
+reorder_impl_items = true
+unstable_features = true
+wrap_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,10 @@ mod xmp_file;
 mod xmp_meta;
 pub mod xmp_ns;
 
-pub use {
-    xmp_date_time::XmpDateTime,
-    xmp_error::{XmpError, XmpErrorType, XmpResult},
-    xmp_file::{OpenFileOptions, XmpFile},
-    xmp_meta::XmpMeta,
-};
+pub use xmp_date_time::XmpDateTime;
+pub use xmp_error::{XmpError, XmpErrorType, XmpResult};
+pub use xmp_file::{OpenFileOptions, XmpFile};
+pub use xmp_meta::XmpMeta;
 
 #[cfg(test)]
 mod tests;

--- a/src/xmp_error.rs
+++ b/src/xmp_error.rs
@@ -11,15 +11,15 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use {
-    crate::ffi::CXmpError,
-    num_enum::FromPrimitive,
-    std::{
-        ffi::{CStr, NulError},
-        fmt,
-    },
-    thiserror::Error,
+use std::{
+    ffi::{CStr, NulError},
+    fmt,
 };
+
+use num_enum::FromPrimitive;
+use thiserror::Error;
+
+use crate::ffi::CXmpError;
 
 /// Describes error conditions returned by most XMP Toolkit operations.
 #[derive(Debug)]
@@ -28,8 +28,9 @@ pub struct XmpError {
     /// A selector for the specific error type.
     pub error_type: XmpErrorType,
 
-    /// Descriptive string, for debugging use only. It must not be shown to users in a final
-    /// product. It is written for developers, not users, and never localized.
+    /// Descriptive string, for debugging use only. It must not be shown to
+    /// users in a final product. It is written for developers, not users,
+    /// and never localized.
     pub debug_message: String,
 }
 
@@ -268,7 +269,8 @@ pub enum XmpErrorType {
     #[error("MPEG format error")]
     BadMpeg = 211,
 
-    /// HEIF format: Modify Operation is not supported for Construction Method 1 or 2.
+    /// HEIF format: Modify Operation is not supported for Construction Method 1
+    /// or 2.
     #[error("HEIF construction method not supported")]
     HeifConstructionMethodNotSupported = 212,
 
@@ -277,7 +279,8 @@ pub enum XmpErrorType {
     BadPng = 213,
 
     // --- Rust-specific errors ---
-    /// Can not convert from Rust string to C string because a NUL byte was found.
+    /// Can not convert from Rust string to C string because a NUL byte was
+    /// found.
     #[error("Unable to convert to C string because a NUL byte was found")]
     NulInRustString = -432,
 }

--- a/src/xmp_file.rs
+++ b/src/xmp_file.rs
@@ -15,18 +15,21 @@ use std::{ffi::CString, path::Path};
 
 use crate::{ffi, XmpError, XmpErrorType, XmpMeta, XmpResult};
 
-/// The `XmpFile` struct allows access to the main (document-level) metadata in a file.
+/// The `XmpFile` struct allows access to the main (document-level) metadata in
+/// a file.
 ///
-/// This provides convenient access to the main, or document level, XMP for a file. Use
-/// it to obtain metadata from a file, which you can then manipulate with the [`XmpMeta`]
-/// struct; and to write new or changed metadata back out to a file.
+/// This provides convenient access to the main, or document level, XMP for a
+/// file. Use it to obtain metadata from a file, which you can then manipulate
+/// with the [`XmpMeta`] struct; and to write new or changed metadata back out
+/// to a file.
 ///
-/// The functions allow you to open a file, read and write the metadata, then close the file.
-/// While open, portions of the file might be maintained in RAM data structures. Memory
-/// usage can vary considerably depending on file format and access options.
+/// The functions allow you to open a file, read and write the metadata, then
+/// close the file. While open, portions of the file might be maintained in RAM
+/// data structures. Memory usage can vary considerably depending on file format
+/// and access options.
 ///
-/// A file can be opened for read-only or read-write access, with typical exclusion for both
-/// modes.
+/// A file can be opened for read-only or read-write access, with typical
+/// exclusion for both modes.
 pub struct XmpFile {
     f: *mut ffi::CXmpFile,
 }
@@ -55,32 +58,36 @@ impl XmpFile {
 
     /// Opens a file for the requested forms of metadata access.
     ///
-    /// Opening the file, at a minimum, causes the raw XMP packet to be read from the file.
-    /// If the file handler supports legacy metadata reconciliation then legacy metadata is
-    /// also read, unless `kXMPFiles_OpenOnlyXMP` is passed.
+    /// Opening the file, at a minimum, causes the raw XMP packet to be read
+    /// from the file. If the file handler supports legacy metadata
+    /// reconciliation then legacy metadata is also read, unless
+    /// `kXMPFiles_OpenOnlyXMP` is passed.
     ///
-    /// If the file is opened for read-only access (passing [`OpenFileOptions::for_read()`]),
-    /// the disk file is closed immediately after reading the data from it; the `XMPFile` struct,
+    /// If the file is opened for read-only access (passing
+    /// [`OpenFileOptions::for_read()`]), the disk file is closed
+    /// immediately after reading the data from it; the `XMPFile` struct,
     /// however, remains in the open state until `drop()` is called.
     ///
-    /// If you update the XMP, you must call [`XmpFile::put_xmp()`] before the struct is dropped;
-    /// if you do not, any pending updates are lost.
+    /// If you update the XMP, you must call [`XmpFile::put_xmp()`] before the
+    /// struct is dropped; if you do not, any pending updates are lost.
     ///
-    /// Typically, the XMP is not parsed and legacy reconciliation is not performed until
-    /// [`XmpFile::xmp()`] is called, but this is not guaranteed. Specific file handlers might
-    /// do earlier parsing of the XMP. Delayed parsing and early disk file close for read-only
-    /// access are optimizations to help clients implementing file browsers, so that they can
-    /// access the file briefly and possibly display a thumbnail, then postpone more expensive
-    /// XMP processing until later.
+    /// Typically, the XMP is not parsed and legacy reconciliation is not
+    /// performed until [`XmpFile::xmp()`] is called, but this is not
+    /// guaranteed. Specific file handlers might do earlier parsing of the
+    /// XMP. Delayed parsing and early disk file close for read-only
+    /// access are optimizations to help clients implementing file browsers, so
+    /// that they can access the file briefly and possibly display a
+    /// thumbnail, then postpone more expensive XMP processing until later.
     ///
     /// ## Arguments
     ///
     /// * `path`: The path for the file.
     ///
-    /// * `flags`: A set of option flags that describe the desired access. By default
-    /// ([`OpenFileOptions::default()`]), the file is opened for read-only access and the
-    /// format handler decides on the level of reconciliation that will be performed.
-    /// See [`OpenFileOptions`] for other options.
+    /// * `flags`: A set of option flags that describe the desired access. By
+    ///   default ([`OpenFileOptions::default()`]), the file is opened for
+    ///   read-only access and the format handler decides on the level of
+    ///   reconciliation that will be performed. See [`OpenFileOptions`] for
+    ///   other options.
     pub fn open_file<P: AsRef<Path>>(&mut self, path: P, flags: OpenFileOptions) -> XmpResult<()> {
         if let Some(c_path) = path_to_cstr(path.as_ref()) {
             let mut err = ffi::CXmpError::default();
@@ -114,12 +121,12 @@ impl XmpFile {
 
     /// Reports whether this file can be updated with a specific XMP packet.
     ///
-    /// Use this function to determine if the file can probably be updated with a
-    /// given set of XMP metadata. This depends on the size of the packet, the
-    /// options with which the file was opened, and the capabilities of the handler
-    /// for the file format. The function obtains the length of the serialized
-    /// packet for the provided XMP, but does not keep it or modify it, and does not
-    /// cause the file to be written when closed.
+    /// Use this function to determine if the file can probably be updated with
+    /// a given set of XMP metadata. This depends on the size of the packet,
+    /// the options with which the file was opened, and the capabilities of
+    /// the handler for the file format. The function obtains the length of
+    /// the serialized packet for the provided XMP, but does not keep it or
+    /// modify it, and does not cause the file to be written when closed.
     pub fn can_put_xmp(&self, meta: &XmpMeta) -> bool {
         let r = unsafe { ffi::CXmpFileCanPutXmp(self.f, meta.m) };
         r != 0
@@ -127,9 +134,10 @@ impl XmpFile {
 
     /// Updates the XMP metadata in this object without writing out the file.
     ///
-    /// This function supplies new XMP for the file. However, the disk file is not written until
-    /// the struct is closed with [`XmpFile::close()`]. The options provided when the file was opened
-    /// determine if reconciliation is done with other forms of metadata.
+    /// This function supplies new XMP for the file. However, the disk file is
+    /// not written until the struct is closed with [`XmpFile::close()`].
+    /// The options provided when the file was opened determine if
+    /// reconciliation is done with other forms of metadata.
     pub fn put_xmp(&mut self, meta: &XmpMeta) -> XmpResult<()> {
         let mut err = ffi::CXmpError::default();
 
@@ -140,20 +148,23 @@ impl XmpFile {
 
     /// Explicitly closes an opened file.
     ///
-    /// Performs any necessary output to the file and closes it. Files that are opened
-    /// for update are written to only when closing.
+    /// Performs any necessary output to the file and closes it. Files that are
+    /// opened for update are written to only when closing.
     ///
-    /// If the file is opened for read-only access (passing [`OpenFileOptions::for_read()`]),
-    /// the disk file is closed immediately after reading the data from it; the `XMPFile`
-    /// struct, however, remains in the open state. You must call [`XmpFile::close()`] when finished
-    /// using it. Other methods, such as [`XmpFile::xmp()`], can only be used between the
-    /// [`XmpFile::open_file()`] and [`XmpFile::close()`] calls. The `XMPFile` destructor does
-    /// not call [`XmpFile::close()`]; if the struct is dropped without closing, any pending
-    /// updates are lost.
+    /// If the file is opened for read-only access (passing
+    /// [`OpenFileOptions::for_read()`]), the disk file is closed
+    /// immediately after reading the data from it; the `XMPFile`
+    /// struct, however, remains in the open state. You must call
+    /// [`XmpFile::close()`] when finished using it. Other methods, such as
+    /// [`XmpFile::xmp()`], can only be used between the
+    /// [`XmpFile::open_file()`] and [`XmpFile::close()`] calls. The `XMPFile`
+    /// destructor does not call [`XmpFile::close()`]; if the struct is
+    /// dropped without closing, any pending updates are lost.
     ///
-    /// If the file is opened for update (passing [`OpenFileOptions::for_update()`]),
-    /// the disk file remains open until [`XmpFile::close()`] is called. The disk file is only
-    /// updated once, when [`XmpFile::close()`] is called, regardless of how many calls are
+    /// If the file is opened for update (passing
+    /// [`OpenFileOptions::for_update()`]), the disk file remains open until
+    /// [`XmpFile::close()`] is called. The disk file is only updated once,
+    /// when [`XmpFile::close()`] is called, regardless of how many calls are
     /// made to [`XmpFile::put_xmp()`].
     pub fn close(&mut self) {
         unsafe { ffi::CXmpFileClose(self.f) };
@@ -252,7 +263,8 @@ impl OpenFileOptions {
         self
     }
 
-    /// When updating a file, spend the effort necessary to optimize file layout.
+    /// When updating a file, spend the effort necessary to optimize file
+    /// layout.
     ///
     /// See `kXMPFiles_OptimizeFileLayout` constant in C++ SDK.
     pub fn optimize_file_layout(mut self) -> Self {

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -74,11 +74,10 @@ impl XmpMeta {
     ///
     /// ## Arguments
     ///
-    /// * `namespace_uri`: The URI for the namespace. Must be a
-    ///   valid XML URI.
+    /// * `namespace_uri`: The URI for the namespace. Must be a valid XML URI.
     ///
-    /// * `suggested_prefix`: The suggested prefix to be used if
-    ///   the URI is not yet registered. Must be a valid XML name.
+    /// * `suggested_prefix`: The suggested prefix to be used if the URI is not
+    ///   yet registered. Must be a valid XML name.
     ///
     /// Returns the prefix actually registered for this URI.
     pub fn register_namespace(namespace_uri: &str, suggested_prefix: &str) -> XmpResult<String> {
@@ -102,22 +101,24 @@ impl XmpMeta {
     /// Gets a property value.
     ///
     /// When specifying a namespace and path (in this and all other accessors):
-    /// * If a namespace URI is specified, it must be for a registered namespace.
-    /// * If the namespace is specified only by a prefix in the property name path,
-    ///   it must be a registered prefix.
+    /// * If a namespace URI is specified, it must be for a registered
+    ///   namespace.
+    /// * If the namespace is specified only by a prefix in the property name
+    ///   path, it must be a registered prefix.
     /// * If both a URI and path prefix are present, they must be corresponding
     ///   parts of a registered namespace.
     ///
     /// ## Arguments
     ///
-    /// * `schema_ns`: The namespace URI for the property. The URI must be for
-    ///   a registered namespace. Must not be an empty string.
+    /// * `schema_ns`: The namespace URI for the property. The URI must be for a
+    ///   registered namespace. Must not be an empty string.
     ///
-    /// * `prop_name`: The name of the property. Can be a general path expression.
-    ///   Must not be an empty string. The first component can be a namespace prefix;
-    ///   if present without a `schema_ns` value, the prefix specifies the namespace.
-    ///   The prefix must be for a registered namespace, and if a namespace URI is
-    ///   specified, must match the registered prefix for that namespace.
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. The first component can be a
+    ///   namespace prefix; if present without a `schema_ns` value, the prefix
+    ///   specifies the namespace. The prefix must be for a registered
+    ///   namespace, and if a namespace URI is specified, must match the
+    ///   registered prefix for that namespace.
     ///
     /// ## Error handling
     ///
@@ -147,8 +148,8 @@ impl XmpMeta {
     ///
     /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
     ///
-    /// * `prop_name`: The name of the property. Can be a general
-    ///   path expression. Must not be an empty string. See [`XmpMeta::property()`]
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
     ///   for namespace prefix usage.
     ///
     /// * `prop_value`: The new value.
@@ -185,8 +186,8 @@ impl XmpMeta {
     ///
     /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
     ///
-    /// * `prop_name`: The name of the property. Can be a general
-    ///   path expression. Must not be an empty string. See [`XmpMeta::property()`]
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
     ///   for namespace prefix usage.
     ///
     /// * `prop_value`: The new value.
@@ -219,8 +220,8 @@ impl XmpMeta {
     ///
     /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
     ///
-    /// * `prop_name`: The name of the property. Can be a general
-    ///   path expression. Must not be an empty string. See [`XmpMeta::property()`]
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
     ///   for namespace prefix usage.
     ///
     /// ## Error handling

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -11,13 +11,12 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use {
-    crate::{ffi, OpenFileOptions, XmpDateTime, XmpError, XmpErrorType, XmpFile, XmpResult},
-    std::{
-        ffi::{CStr, CString},
-        path::Path,
-    },
+use std::{
+    ffi::{CStr, CString},
+    path::Path,
 };
+
+use crate::{ffi, OpenFileOptions, XmpDateTime, XmpError, XmpErrorType, XmpFile, XmpResult};
 
 /// The `XmpMeta` struct allows access to the XMP Toolkit core services.
 ///

--- a/src/xmp_ns.rs
+++ b/src/xmp_ns.rs
@@ -45,7 +45,8 @@ pub const IDENTIFIER_QUAL: &str = "http://ns.adobe.com/xmp/Identifier/qual/1.0/"
 /// The XML namespace for fields of the `Dimensions` type.
 pub const DIMENSIONS: &str = "http://ns.adobe.com/xap/1.0/sType/Dimensions#";
 
-/// The XML namespace for fields of a graphical image. Used for the `Thumbnail` type.
+/// The XML namespace for fields of a graphical image. Used for the `Thumbnail`
+/// type.
 pub const IMAGE: &str = "http://ns.adobe.com/xap/1.0/g/img/";
 
 /// The XML namespace for fields of the `ResourceEvent` type.


### PR DESCRIPTION
Use several options from rustfmt nightly build
