### PR TITLE
(MINOR) Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [1.54.0]
+        rust_version: [1.56.0]
 
     steps:
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       # Note that we do not run code coverage because
-      # it was not stabilized as of 1.54.0.
+      # it was not stabilized as of 1.56.0.
 
       - name: Run self tests
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Eric Scouten <scouten@adobe.com>"]
 keywords = ["xmp", "metadata"]
 categories = ["api-bindings"]
 edition = "2018"
-rust-version = "1.54.0"
+rust-version = "1.56.0"
 exclude = [
     "external/xmp_toolkit/docs",
     "external/xmp_toolkit/samples",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Contributions that ...
 
 ## Rust language support
 
-As of this writing, this crate requires **Rust version 1.54** or newer. (The CI builds use this version of Rust.) This may be increased to a newer version at any time, but will be noted in the changelog.
+As of this writing, this crate requires **Rust version 1.56** or newer. (The CI builds use this version of Rust.) This may be increased to a newer version at any time, but will be noted in the changelog.
 
 This crate follows all of the typical Rust conventions (`cargo build`, `cargo test`, etc.). There is a `build.rs` script which will ensure that the C++ portions of the library are built as needed. It may need to be updated for platforms that haven't already been tested.
 

--- a/src/xmp_error.rs
+++ b/src/xmp_error.rs
@@ -77,7 +77,7 @@ impl fmt::Display for XmpError {
 impl std::error::Error for XmpError {}
 
 /// Describes which error type occurred.
-#[derive(Debug, Error, FromPrimitive, PartialEq)]
+#[derive(Debug, Eq, Error, FromPrimitive, PartialEq)]
 #[non_exhaustive]
 #[repr(i32)]
 pub enum XmpErrorType {


### PR DESCRIPTION
Some dependent crates now require Rust edition 2021, which was not supported until Rust 1.56.