### PR TITLE
(MINOR) Rework `XmpDateTime` as a non-opaque type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ xmp_toolkit = "0.5.3"
 
 ### Upgrading to 0.6 from earlier versions
 
-The `XmpDateTime` struct has been meaningfully implemented, meaning is has changed
-from an opaque type to one containing the date, time, and time zone values as
+The `XmpDateTime` struct has been meaningfully implemented, meaning it has changed
+from an opaque type to a struct containing the date, time, and time zone values as
 present in the C++ toolkit.
 
 The `XmpMeta::property` method has been changed to return `Option<XmpValue<String>>`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ xmp_toolkit = "0.5.3"
 
 ### Upgrading to 0.6 from earlier versions
 
-The `XmpMeta::property` value has been changed to return `Option<XmpValue<String>>`
+The `XmpDateTime` struct has been meaningfully implemented, meaning is has changed
+from an opaque type to one containing the date, time, and time zone values as
+present in the C++ toolkit.
+
+The `XmpMeta::property` method has been changed to return `Option<XmpValue<String>>`
 instead of `Option<String>`. You may need to add a `.value` dereference to get the
 string value from existing calls to the `property` accessor. The XMP value flags
 (known as `XMP_OptionBits` in the C++ XMP Toolkit) are now available via accessors

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -134,14 +134,6 @@ extern "C" {
         #endif
     } CXmpMeta;
 
-    typedef struct CXmpDateTime {
-        #ifdef NOOP_FFI
-            int x;
-        #else
-            XMP_DateTime dt;
-        #endif
-    } CXmpDateTime;
-
     // --- CXmpFile ---
 
     CXmpFile* CXmpFileNew(CXmpError* outError) {
@@ -390,13 +382,13 @@ extern "C" {
                                  CXmpError* outError,
                                  const char* schemaNS,
                                  const char* propName,
-                                 const CXmpDateTime* propValue) {
+                                 const XMP_DateTime* propValue) {
         #ifndef NOOP_FFI
             // TO DO: Bridge options parameter.
             // For my purposes at the moment,
             // default value (0) always suffices.
             try {
-                m->m.SetProperty_Date(schemaNS, propName, propValue->dt);
+                m->m.SetProperty_Date(schemaNS, propName, *propValue);
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);
@@ -440,27 +432,12 @@ extern "C" {
 
     // --- CXmpDateTime ---
 
-    CXmpDateTime* CXmpDateTimeNew() {
-        // As of this writing (2022-07-09,
-        // https://github.com/adobe/XMP-Toolkit-SDK/blob/337c052b059640e243dbd6646b9462edaf6038c1/public/include/XMP_Const.h#L230),
-        // XMP_DateTime does not throw on construction.
-        return new CXmpDateTime;
-    }
-
-    void CXmpDateTimeDrop(CXmpDateTime* dt) {
-        // As of this writing (2022-07-09,
-        // https://github.com/adobe/XMP-Toolkit-SDK/blob/337c052b059640e243dbd6646b9462edaf6038c1/public/include/XMP_Const.h#L230),
-        // XMP_DateTime does not have a destructor and its member types are simple,
-        // so it does not throw on destruction.
-        delete dt;
-    }
-
-    CXmpDateTime* CXmpDateTimeCurrent(CXmpError* outError) {
+    void CXmpDateTimeCurrent(XMP_DateTime* dt, CXmpError* outError) {
         #ifndef NOOP_FFI
             try {
-                CXmpDateTime* dt = new CXmpDateTime;
-                SXMPUtils::CurrentDateTime(&dt->dt);
-                return dt;
+                if (dt) {
+                    SXMPUtils::CurrentDateTime(dt);
+                }
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);
@@ -469,7 +446,5 @@ extern "C" {
                 signalUnknownError(outError);
             }
         #endif
-
-        return NULL;
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,7 +30,24 @@ impl Default for CXmpError {
     }
 }
 
-pub(crate) enum CXmpDateTime {}
+#[derive(Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub(crate) struct CXmpDateTime {
+    pub(crate) year: i32,
+    pub(crate) month: i32,
+    pub(crate) day: i32,
+    pub(crate) hour: i32,
+    pub(crate) minute: i32,
+    pub(crate) second: i32,
+    pub(crate) has_date: bool,
+    pub(crate) has_time: bool,
+    pub(crate) has_time_zone: bool,
+    pub(crate) tz_sign: i8,
+    pub(crate) tz_hour: i32,
+    pub(crate) tz_minute: i32,
+    pub(crate) nanosecond: i32,
+}
+
 pub(crate) enum CXmpFile {}
 pub(crate) enum CXmpMeta {}
 
@@ -116,7 +133,5 @@ extern "C" {
 
     // --- CXmpDateTime ---
 
-    pub(crate) fn CXmpDateTimeNew() -> *mut CXmpDateTime;
-    pub(crate) fn CXmpDateTimeDrop(dt: *mut CXmpDateTime);
-    pub(crate) fn CXmpDateTimeCurrent(out_error: *mut CXmpError) -> *mut CXmpDateTime;
+    pub(crate) fn CXmpDateTimeCurrent(dt: *mut CXmpDateTime, out_error: *mut CXmpError);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod xmp_meta;
 pub mod xmp_ns;
 mod xmp_value;
 
-pub use xmp_date_time::XmpDateTime;
+pub use xmp_date_time::{XmpDate, XmpDateTime, XmpTime, XmpTimeZone};
 pub use xmp_error::{XmpError, XmpErrorType, XmpResult};
 pub use xmp_file::{OpenFileOptions, XmpFile};
 pub use xmp_meta::{ArrayProperty, XmpMeta};

--- a/src/tests/xmp_date_time.rs
+++ b/src/tests/xmp_date_time.rs
@@ -14,16 +14,20 @@
 use crate::XmpDateTime;
 
 #[test]
-fn new_empty() {
-    let mut _dt = XmpDateTime::new();
-}
-
-#[test]
 fn default() {
-    let mut _dt = XmpDateTime::default();
+    let dt = XmpDateTime::default();
+    assert!(dt.date.is_none());
+    assert!(dt.time.is_none());
 }
 
 #[test]
 fn current() {
-    let mut _dt = XmpDateTime::current().unwrap();
+    let dt = XmpDateTime::current().unwrap();
+
+    let date = dt.date.as_ref().unwrap();
+    assert!(date.year >= 2022);
+    assert!(date.month >= 1);
+    assert!(date.month <= 12);
+    assert!(date.day >= 1);
+    assert!(date.day <= 31);
 }

--- a/src/tests/xmp_date_time.rs
+++ b/src/tests/xmp_date_time.rs
@@ -11,13 +11,29 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::XmpDateTime;
+use crate::{XmpDate, XmpDateTime, XmpTime, XmpTimeZone};
 
 #[test]
 fn default() {
     let dt = XmpDateTime::default();
     assert!(dt.date.is_none());
     assert!(dt.time.is_none());
+
+    let date = XmpDate::default();
+    assert_eq!(date.year, 0);
+    assert_eq!(date.month, 0);
+    assert_eq!(date.day, 0);
+
+    let time = XmpTime::default();
+    assert_eq!(time.hour, 0);
+    assert_eq!(time.minute, 0);
+    assert_eq!(time.second, 0);
+    assert_eq!(time.nanosecond, 0);
+    assert!(time.time_zone.is_none());
+
+    let tz = XmpTimeZone::default();
+    assert_eq!(tz.hour, 0);
+    assert_eq!(tz.minute, 0);
 }
 
 #[test]
@@ -30,4 +46,508 @@ fn current() {
     assert!(date.month <= 12);
     assert!(date.day >= 1);
     assert!(date.day <= 31);
+}
+
+mod from_ffi {
+    use crate::{ffi, XmpDate, XmpDateTime, XmpTime, XmpTimeZone};
+
+    #[test]
+    fn fully_populated_west_of_utc() {
+        let dt = ffi::CXmpDateTime {
+            year: 2022,
+            month: 10,
+            day: 19,
+            hour: 18,
+            minute: 9,
+            second: 20,
+            has_date: true,
+            has_time: true,
+            has_time_zone: true,
+            tz_sign: -1,
+            tz_hour: 7,
+            tz_minute: 0,
+            nanosecond: 42,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: Some(XmpDate {
+                    year: 2022,
+                    month: 10,
+                    day: 19,
+                }),
+                time: Some(XmpTime {
+                    hour: 18,
+                    minute: 9,
+                    second: 20,
+                    nanosecond: 42,
+                    time_zone: Some(XmpTimeZone {
+                        hour: -7,
+                        minute: 0,
+                    }),
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn fully_populated_east_of_utc() {
+        let dt = ffi::CXmpDateTime {
+            year: 2022,
+            month: 10,
+            day: 19,
+            hour: 18,
+            minute: 9,
+            second: 20,
+            has_date: true,
+            has_time: true,
+            has_time_zone: true,
+            tz_sign: 1,
+            tz_hour: 5,
+            tz_minute: 30,
+            nanosecond: 42,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: Some(XmpDate {
+                    year: 2022,
+                    month: 10,
+                    day: 19,
+                }),
+                time: Some(XmpTime {
+                    hour: 18,
+                    minute: 9,
+                    second: 20,
+                    nanosecond: 42,
+                    time_zone: Some(XmpTimeZone {
+                        hour: 5,
+                        minute: 30,
+                    }),
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn fully_populated_utc() {
+        let dt = ffi::CXmpDateTime {
+            year: 2022,
+            month: 10,
+            day: 19,
+            hour: 18,
+            minute: 9,
+            second: 20,
+            has_date: true,
+            has_time: true,
+            has_time_zone: true,
+            tz_sign: 0,
+            tz_hour: 0,
+            tz_minute: 0,
+            nanosecond: 42,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: Some(XmpDate {
+                    year: 2022,
+                    month: 10,
+                    day: 19,
+                }),
+                time: Some(XmpTime {
+                    hour: 18,
+                    minute: 9,
+                    second: 20,
+                    nanosecond: 42,
+                    time_zone: Some(XmpTimeZone { hour: 0, minute: 0 }),
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn no_time_zone() {
+        let dt = ffi::CXmpDateTime {
+            year: 2022,
+            month: 10,
+            day: 19,
+            hour: 18,
+            minute: 9,
+            second: 20,
+            has_date: true,
+            has_time: true,
+            has_time_zone: false,
+            tz_sign: 0,
+            tz_hour: 0,
+            tz_minute: 0,
+            nanosecond: 42,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: Some(XmpDate {
+                    year: 2022,
+                    month: 10,
+                    day: 19,
+                }),
+                time: Some(XmpTime {
+                    hour: 18,
+                    minute: 9,
+                    second: 20,
+                    nanosecond: 42,
+                    time_zone: None,
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn no_time() {
+        let dt = ffi::CXmpDateTime {
+            year: 2022,
+            month: 10,
+            day: 19,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            has_date: true,
+            has_time: false,
+            has_time_zone: false,
+            tz_sign: 0,
+            tz_hour: 0,
+            tz_minute: 0,
+            nanosecond: 0,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: Some(XmpDate {
+                    year: 2022,
+                    month: 10,
+                    day: 19,
+                }),
+                time: None
+            }
+        );
+    }
+
+    #[test]
+    fn no_date() {
+        let dt = ffi::CXmpDateTime {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 18,
+            minute: 9,
+            second: 20,
+            has_date: false,
+            has_time: true,
+            has_time_zone: true,
+            tz_sign: -1,
+            tz_hour: 7,
+            tz_minute: 0,
+            nanosecond: 42,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: None,
+                time: Some(XmpTime {
+                    hour: 18,
+                    minute: 9,
+                    second: 20,
+                    nanosecond: 42,
+                    time_zone: Some(XmpTimeZone {
+                        hour: -7,
+                        minute: 0,
+                    }),
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn no_date_or_time() {
+        let dt = ffi::CXmpDateTime {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            has_date: false,
+            has_time: false,
+            has_time_zone: false,
+            tz_sign: 0,
+            tz_hour: 0,
+            tz_minute: 0,
+            nanosecond: 0,
+        };
+
+        assert_eq!(
+            XmpDateTime::from_ffi(&dt),
+            XmpDateTime {
+                date: None,
+                time: None
+            }
+        );
+    }
+}
+
+mod as_ffi {
+    use crate::{ffi, XmpDate, XmpDateTime, XmpTime, XmpTimeZone};
+
+    #[test]
+    fn fully_populated_west_of_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: -7,
+                    minute: 0,
+                }),
+            }),
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 2022,
+                month: 10,
+                day: 19,
+                hour: 18,
+                minute: 9,
+                second: 20,
+                has_date: true,
+                has_time: true,
+                has_time_zone: true,
+                tz_sign: -1,
+                tz_hour: 7,
+                tz_minute: 0,
+                nanosecond: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn fully_populated_east_of_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: 5,
+                    minute: 30,
+                }),
+            }),
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 2022,
+                month: 10,
+                day: 19,
+                hour: 18,
+                minute: 9,
+                second: 20,
+                has_date: true,
+                has_time: true,
+                has_time_zone: true,
+                tz_sign: 1,
+                tz_hour: 5,
+                tz_minute: 30,
+                nanosecond: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn fully_populated_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone { hour: 0, minute: 0 }),
+            }),
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 2022,
+                month: 10,
+                day: 19,
+                hour: 18,
+                minute: 9,
+                second: 20,
+                has_date: true,
+                has_time: true,
+                has_time_zone: true,
+                tz_sign: 0,
+                tz_hour: 0,
+                tz_minute: 0,
+                nanosecond: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn no_time_zone() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: None,
+            }),
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 2022,
+                month: 10,
+                day: 19,
+                hour: 18,
+                minute: 9,
+                second: 20,
+                has_date: true,
+                has_time: true,
+                has_time_zone: false,
+                tz_sign: 0,
+                tz_hour: 0,
+                tz_minute: 0,
+                nanosecond: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn no_time() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: None,
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 2022,
+                month: 10,
+                day: 19,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                has_date: true,
+                has_time: false,
+                has_time_zone: false,
+                tz_sign: 0,
+                tz_hour: 0,
+                tz_minute: 0,
+                nanosecond: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn no_date() {
+        let dt = XmpDateTime {
+            date: None,
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: -7,
+                    minute: 0,
+                }),
+            }),
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                hour: 18,
+                minute: 9,
+                second: 20,
+                has_date: false,
+                has_time: true,
+                has_time_zone: true,
+                tz_sign: -1,
+                tz_hour: 7,
+                tz_minute: 0,
+                nanosecond: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn no_date_or_time() {
+        let dt = XmpDateTime {
+            date: None,
+            time: None,
+        };
+
+        assert_eq!(
+            dt.as_ffi(),
+            ffi::CXmpDateTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                has_date: false,
+                has_time: false,
+                has_time_zone: false,
+                tz_sign: 0,
+                tz_hour: 0,
+                tz_minute: 0,
+                nanosecond: 0,
+            }
+        );
+    }
 }

--- a/src/xmp_date_time.rs
+++ b/src/xmp_date_time.rs
@@ -147,7 +147,7 @@ impl XmpDateTime {
 
             if let Some(tz) = &time.time_zone {
                 result.has_time_zone = true;
-                match result.tz_hour {
+                match tz.hour {
                     h if h < 0 => {
                         result.tz_sign = -1;
                         result.tz_hour = -h;

--- a/src/xmp_date_time.rs
+++ b/src/xmp_date_time.rs
@@ -13,44 +13,158 @@
 
 use crate::{ffi, XmpError, XmpResult};
 
-/// The expanded type for a date and time.
+/// The `XmpDateTime` struct allows easy conversion between ISO8601 format
+/// (the "native" representation of dates and times in XMP) and other formats.
 ///
-/// Dates and time in the serialized XMP are ISO 8601 strings.
-/// The `XmpDateTime` struct allows easy conversion with other formats.
+/// All of the fields are signed 32 bit integers, even though most could be 8
+/// bit. (The same is true in the underlying C++ XMP Toolkit.) This avoids
+/// overflow when doing carries for arithmetic or normalization.
+///
+/// `XmpDateTime` values are occasionally used with only a date or only a time
+/// component. These possibilities are expressed using `Option`s.
+///
+/// Note that the [`DateTime` struct in the `chrono` crate`](https://docs.rs/chrono/0.4.22/chrono/struct.DateTime.html)
+/// is _similar_ to this struct. We chose not to use that in the
+/// Rust XMP Toolkit in order to provide a more precise mapping
+/// to the API provided by the underlying C++ XMP Toolkit.
+#[derive(Default, Debug, Eq, PartialEq)]
 pub struct XmpDateTime {
-    pub(crate) dt: *mut ffi::CXmpDateTime,
+    /// The date, if known.
+    pub date: Option<XmpDate>,
+
+    /// The time, if known.
+    pub time: Option<XmpTime>,
 }
 
-impl Drop for XmpDateTime {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::CXmpDateTimeDrop(self.dt);
-        }
-    }
+/// The date portion of [`XmpDateTime`].
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct XmpDate {
+    /// The year, can be negative.
+    pub year: i32,
+
+    /// The month in the range 1..12.
+    pub month: i32,
+
+    /// The day of the month in the range 1..31.
+    pub day: i32,
 }
 
-impl Default for XmpDateTime {
-    fn default() -> Self {
-        Self::new()
-    }
+/// The time portion of [`XmpDateTime`].
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct XmpTime {
+    /// The hour in the range 0..23.
+    pub hour: i32,
+
+    /// The minute in the range 0..59.
+    pub minute: i32,
+
+    /// The second in the range 0..59.
+    pub second: i32,
+
+    /// Nanoseconds within a second, often left as zero.
+    pub nanosecond: i32,
+
+    /// The time zone, if known.
+    pub time_zone: Option<XmpTimeZone>,
+}
+
+/// The time zone portion of [`XmpTime`].
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct XmpTimeZone {
+    /// The time zone hour in the range -23..+23.
+    /// Negative numbers are west of UTC; positive numbers are east.
+    pub hour: i32,
+
+    /// The time zone minute in the range 0..59.
+    pub minute: i32,
 }
 
 impl XmpDateTime {
-    /// Creates a new date-time struct with zeros in all fields.
-    pub fn new() -> Self {
-        Self {
-            dt: unsafe { ffi::CXmpDateTimeNew() },
-        }
-    }
-
     /// Creates a new date-time struct reflecting the current time.
     pub fn current() -> XmpResult<Self> {
+        let mut dt = ffi::CXmpDateTime::default();
         let mut err = ffi::CXmpError::default();
 
-        let dt = unsafe { ffi::CXmpDateTimeCurrent(&mut err) };
+        unsafe { ffi::CXmpDateTimeCurrent(&mut dt, &mut err) };
 
         XmpError::raise_from_c(&err)?;
 
-        Ok(XmpDateTime { dt })
+        Ok(Self::from_ffi(&dt))
+    }
+
+    pub(crate) fn from_ffi(dt: &ffi::CXmpDateTime) -> Self {
+        Self {
+            date: if dt.has_date {
+                Some(XmpDate {
+                    year: dt.year,
+                    month: dt.month,
+                    day: dt.day,
+                })
+            } else {
+                None
+            },
+            time: if dt.has_time {
+                Some(XmpTime {
+                    hour: dt.hour,
+                    minute: dt.minute,
+                    second: dt.second,
+                    nanosecond: dt.nanosecond,
+                    time_zone: if dt.has_time_zone {
+                        Some(XmpTimeZone {
+                            hour: if dt.tz_sign < 0 {
+                                -dt.tz_hour
+                            } else {
+                                dt.tz_hour
+                            },
+                            minute: dt.tz_minute,
+                        })
+                    } else {
+                        None
+                    },
+                })
+            } else {
+                None
+            },
+        }
+    }
+
+    pub(crate) fn as_ffi(&self) -> ffi::CXmpDateTime {
+        let mut result = ffi::CXmpDateTime::default();
+
+        if let Some(date) = &self.date {
+            result.has_date = true;
+            result.year = date.year;
+            result.month = date.month;
+            result.day = date.day;
+        }
+
+        if let Some(time) = &self.time {
+            result.has_time = true;
+            result.hour = time.hour;
+            result.minute = time.minute;
+            result.second = time.second;
+            result.nanosecond = time.nanosecond;
+
+            if let Some(tz) = &time.time_zone {
+                result.has_time_zone = true;
+                match result.tz_hour {
+                    h if h < 0 => {
+                        result.tz_sign = -1;
+                        result.tz_hour = -h;
+                    }
+                    0 if tz.minute == 0 => {
+                        result.tz_sign = 0;
+                        result.tz_hour = 0;
+                    }
+                    h => {
+                        result.tz_sign = 1;
+                        result.tz_hour = h;
+                    }
+                };
+                result.tz_minute = tz.minute;
+            }
+        }
+
+        result
     }
 }

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -225,7 +225,7 @@ impl XmpMeta {
                 &mut err,
                 c_ns.as_ptr(),
                 c_name.as_ptr(),
-                prop_value.dt,
+                &prop_value.as_ffi(),
             );
         }
 


### PR DESCRIPTION
## Changes in this pull request
`XmpDateTime` now meaningfully mirrors the corresponding C++ struct. This will facilitate upcoming implementation of date-time APIs.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
