### PR TITLE
(MINOR) `XmpMeta::set_property` can now pass `XmpValue` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,21 @@ xmp_toolkit = "0.5.3"
 
 ### Upgrading to 0.6 from earlier versions
 
-The `XmpDateTime` struct has been meaningfully implemented, meaning it has changed
-from an opaque type to a struct containing the date, time, and time zone values as
-present in the C++ toolkit.
-
 The `XmpMeta::property` method has been changed to return `Option<XmpValue<String>>`
 instead of `Option<String>`. You may need to add a `.value` dereference to get the
 string value from existing calls to the `property` accessor. The XMP value flags
 (known as `XMP_OptionBits` in the C++ XMP Toolkit) are now available via accessors
 on the new `XmpValue` struct.
+
+The `XmpMeta::set_property` and `XmpMeta::set_property_date` methods have been changed
+to require `XmpValue<String>` and `XmpValue<XmpDateTime>`, respectively. This allows
+you to pass XMP value flags when setting values. `XmpValue<T>` implements `From<T>`,
+so in most cases, the default/pre-existing behavior can be retained by adding `.into()`
+at the call sites.
+
+The `XmpDateTime` struct has been meaningfully implemented, meaning it has changed
+from an opaque type to a struct containing the date, time, and time zone values as
+present in the C++ toolkit.
 
 This version also increases the minimum supported Rust version (MSRV) to 1.56.0.
 

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -346,13 +346,11 @@ extern "C" {
                              CXmpError* outError,
                              const char* schemaNS,
                              const char* propName,
-                             const char* propValue) {
+                             const char* propValue,
+                             AdobeXMPCommon::uint32 options) {
         #ifndef NOOP_FFI
-            // TO DO: Bridge options parameter.
-            // For my purposes at the moment,
-            // default value (0) always suffices.
             try {
-                m->m.SetProperty(schemaNS, propName, propValue);
+                m->m.SetProperty(schemaNS, propName, propValue, options);
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -380,13 +380,11 @@ extern "C" {
                                  CXmpError* outError,
                                  const char* schemaNS,
                                  const char* propName,
-                                 const XMP_DateTime* propValue) {
+                                 const XMP_DateTime* propValue,
+                                 AdobeXMPCommon::uint32 options) {
         #ifndef NOOP_FFI
-            // TO DO: Bridge options parameter.
-            // For my purposes at the moment,
-            // default value (0) always suffices.
             try {
-                m->m.SetProperty_Date(schemaNS, propName, *propValue);
+                m->m.SetProperty_Date(schemaNS, propName, *propValue, options);
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -106,6 +106,7 @@ extern "C" {
         schema_ns: *const c_char,
         prop_name: *const c_char,
         prop_value: *const c_char,
+        options: u32,
     );
 
     pub(crate) fn CXmpMetaDoesPropertyExist(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -121,6 +121,7 @@ extern "C" {
         schema_ns: *const c_char,
         prop_name: *const c_char,
         prop_value: *const CXmpDateTime,
+        options: u32,
     );
 
     pub(crate) fn CXmpMetaGetArrayItem(

--- a/src/tests/xmp_file.rs
+++ b/src/tests/xmp_file.rs
@@ -33,7 +33,7 @@ fn open_and_edit_file() {
         XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
 
         let mut m = f.xmp().unwrap();
-        m.set_property("http://purl.org/dc/terms/", "provenance", "blah")
+        m.set_property("http://purl.org/dc/terms/", "provenance", &"blah".into())
             .unwrap();
 
         assert!(m.does_property_exist("http://purl.org/dc/terms/", "provenance"));
@@ -140,7 +140,7 @@ mod can_put_xmp {
         XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
 
         let mut m = XmpMeta::new().unwrap();
-        m.set_property("http://purl.org/dc/terms/", "provenance", "blah")
+        m.set_property("http://purl.org/dc/terms/", "provenance", &"blah".into())
             .unwrap();
 
         assert!(!f.can_put_xmp(&m));
@@ -165,7 +165,7 @@ mod put_xmp {
         XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
 
         let mut m = XmpMeta::new().unwrap();
-        m.set_property("http://purl.org/dc/terms/", "provenance", "blah")
+        m.set_property("http://purl.org/dc/terms/", "provenance", &"blah".into())
             .unwrap();
 
         let err = f.put_xmp(&m).unwrap_err();

--- a/src/tests/xmp_file.rs
+++ b/src/tests/xmp_file.rs
@@ -41,7 +41,7 @@ fn open_and_edit_file() {
 
         if m.does_property_exist(xmp_ns::XMP, "MetadataDate") {
             let updated_time = XmpDateTime::current().unwrap();
-            m.set_property_date(xmp_ns::XMP, "MetadataDate", &updated_time)
+            m.set_property_date(xmp_ns::XMP, "MetadataDate", &updated_time.into())
                 .unwrap();
         }
 

--- a/src/xmp_date_time.rs
+++ b/src/xmp_date_time.rs
@@ -27,7 +27,7 @@ use crate::{ffi, XmpError, XmpResult};
 /// is _similar_ to this struct. We chose not to use that in the
 /// Rust XMP Toolkit in order to provide a more precise mapping
 /// to the API provided by the underlying C++ XMP Toolkit.
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct XmpDateTime {
     /// The date, if known.
     pub date: Option<XmpDate>,
@@ -37,7 +37,7 @@ pub struct XmpDateTime {
 }
 
 /// The date portion of [`XmpDateTime`].
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct XmpDate {
     /// The year, can be negative.
     pub year: i32,
@@ -50,7 +50,7 @@ pub struct XmpDate {
 }
 
 /// The time portion of [`XmpDateTime`].
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct XmpTime {
     /// The hour in the range 0..23.
     pub hour: i32,
@@ -69,7 +69,7 @@ pub struct XmpTime {
 }
 
 /// The time zone portion of [`XmpTime`].
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct XmpTimeZone {
     /// The time zone hour in the range -23..+23.
     /// Negative numbers are west of UTC; positive numbers are east.

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -214,7 +214,7 @@ impl XmpMeta {
         &mut self,
         schema_ns: &str,
         prop_name: &str,
-        prop_value: &XmpDateTime,
+        prop_value: &XmpValue<XmpDateTime>,
     ) -> XmpResult<()> {
         let c_ns = CString::new(schema_ns)?;
         let c_name = CString::new(prop_name)?;
@@ -226,7 +226,8 @@ impl XmpMeta {
                 &mut err,
                 c_ns.as_ptr(),
                 c_name.as_ptr(),
-                &prop_value.as_ffi(),
+                &prop_value.value.as_ffi(),
+                prop_value.options,
             );
         }
 

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -197,7 +197,7 @@ impl XmpMeta {
     }
 
     /// Creates or sets a property value using an [`XmpDateTime`] structure.
-    /// 
+    ///
     /// Since XMP only stores strings, the date/time will be converted to
     /// ISO 8601 format as part of this operation.
     ///

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -175,11 +175,11 @@ impl XmpMeta {
         &mut self,
         schema_ns: &str,
         prop_name: &str,
-        prop_value: &str,
+        prop_value: &XmpValue<String>,
     ) -> XmpResult<()> {
         let c_ns = CString::new(schema_ns)?;
         let c_name = CString::new(prop_name)?;
-        let c_value = CString::new(prop_value)?;
+        let c_value = CString::new(prop_value.value.as_bytes())?;
         let mut err = ffi::CXmpError::default();
 
         unsafe {
@@ -189,6 +189,7 @@ impl XmpMeta {
                 c_ns.as_ptr(),
                 c_name.as_ptr(),
                 c_value.as_ptr(),
+                prop_value.options,
             );
         }
 

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -197,9 +197,9 @@ impl XmpMeta {
     }
 
     /// Creates or sets a property value using an [`XmpDateTime`] structure.
-    ///
-    /// This is the simplest property setter. Use it for top-level
-    /// simple properties.
+    /// 
+    /// Since XMP only stores strings, the date/time will be converted to
+    /// ISO 8601 format as part of this operation.
     ///
     /// ## Arguments
     ///

--- a/src/xmp_value.rs
+++ b/src/xmp_value.rs
@@ -291,3 +291,12 @@ impl<T: Clone + Debug + Default + Eq + PartialEq> From<T> for XmpValue<T> {
         Self { value, options: 0 }
     }
 }
+
+impl From<&str> for XmpValue<String> {
+    fn from(value: &str) -> Self {
+        Self {
+            value: value.to_owned(),
+            options: 0,
+        }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
`XmpMeta::set_property` and `XmpMeta::set_property_date` have both been revised to accept `XmpValue<String>` or `XmpValue<XmpDateTime>`, respectively. This allows options to be passed along with the underlying value.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
