### PR TITLE
Add typed property getters

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -342,6 +342,136 @@ extern "C" {
         return NULL;
     }
 
+    bool CXmpMetaGetProperty_Bool(CXmpMeta* m,
+                                  CXmpError* outError,
+                                  const char* schemaNS,
+                                  const char* propName,
+                                  bool* outValue,
+                                  AdobeXMPCommon::uint32* outOptions) {
+        *outOptions = 0;
+
+        #ifndef NOOP_FFI
+            try {
+                std::string propValue;
+                if (m->m.GetProperty_Bool(schemaNS, propName, outValue, outOptions)) {
+                    return true;
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return false;
+    }
+    
+	bool CXmpMetaGetProperty_Int(CXmpMeta* m,
+                                 CXmpError* outError,
+                                 const char* schemaNS,
+                                 const char* propName,
+                                 AdobeXMPCommon::int32* outValue,
+                                 AdobeXMPCommon::uint32* outOptions) {
+        *outOptions = 0;
+
+        #ifndef NOOP_FFI
+            try {
+                std::string propValue;
+                if (m->m.GetProperty_Int(schemaNS, propName, outValue, outOptions)) {
+                    return true;
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return false;
+    }
+
+	bool CXmpMetaGetProperty_Int64(CXmpMeta* m,
+                                   CXmpError* outError,
+                                   const char* schemaNS,
+                                   const char* propName,
+                                   AdobeXMPCommon::int64* outValue,
+                                   AdobeXMPCommon::uint32* outOptions) {
+        *outOptions = 0;
+
+        #ifndef NOOP_FFI
+            try {
+                std::string propValue;
+                if (m->m.GetProperty_Int64(schemaNS, propName, outValue, outOptions)) {
+                    return true;
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return false;
+    }
+
+	bool CXmpMetaGetProperty_Float(CXmpMeta* m,
+                                   CXmpError* outError,
+                                   const char* schemaNS,
+                                   const char* propName,
+                                   double* outValue,
+                                   AdobeXMPCommon::uint32* outOptions) {
+        *outOptions = 0;
+
+        #ifndef NOOP_FFI
+            try {
+                std::string propValue;
+                if (m->m.GetProperty_Float(schemaNS, propName, outValue, outOptions)) {
+                    return true;
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return NULL;
+    }
+    
+    bool CXmpMetaGetProperty_Date(CXmpMeta* m,
+                                  CXmpError* outError,
+                                  const char* schemaNS,
+                                  const char* propName,
+                                  XMP_DateTime* outValue,
+                                  AdobeXMPCommon::uint32* outOptions) {
+        *outOptions = 0;
+
+        #ifndef NOOP_FFI
+            try {
+                std::string propValue;
+                if (m->m.GetProperty_Date(schemaNS, propName, outValue, outOptions)) {
+                    return true;
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return false;
+    }
+
     void CXmpMetaSetProperty(CXmpMeta* m,
                              CXmpError* outError,
                              const char* schemaNS,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -100,6 +100,51 @@ extern "C" {
         out_options: *mut u32,
     ) -> *mut c_char;
 
+    pub(crate) fn CXmpMetaGetProperty_Bool(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        schema_ns: *const c_char,
+        prop_name: *const c_char,
+        out_value: *mut bool,
+        out_options: *mut u32,
+    ) -> bool;
+
+    pub(crate) fn CXmpMetaGetProperty_Int(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        schema_ns: *const c_char,
+        prop_name: *const c_char,
+        out_value: *mut i32,
+        out_options: *mut u32,
+    ) -> bool;
+
+    pub(crate) fn CXmpMetaGetProperty_Int64(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        schema_ns: *const c_char,
+        prop_name: *const c_char,
+        out_value: *mut i64,
+        out_options: *mut u32,
+    ) -> bool;
+
+    pub(crate) fn CXmpMetaGetProperty_Float(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        schema_ns: *const c_char,
+        prop_name: *const c_char,
+        out_value: *mut f64,
+        out_options: *mut u32,
+    ) -> bool;
+
+    pub(crate) fn CXmpMetaGetProperty_Date(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        schema_ns: *const c_char,
+        prop_name: *const c_char,
+        out_value: *mut CXmpDateTime,
+        out_options: *mut u32,
+    ) -> bool;
+
     pub(crate) fn CXmpMetaSetProperty(
         meta: *mut CXmpMeta,
         out_error: *mut CXmpError,

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -206,6 +206,293 @@ mod property {
     }
 }
 
+mod property_bool {
+    use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
+
+    #[test]
+    fn happy_path() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_bool(xmp_ns::XMP_RIGHTS, "Marked"),
+            Some(XmpValue {
+                value: false,
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn unrecognizable_as_bool() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_bool(xmp_ns::XMP, "CreatorTool"), None);
+    }
+
+    #[test]
+    fn value_1_is_true() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_bool(xmp_ns::TIFF, "Orientation"),
+            Some(XmpValue {
+                value: true,
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_bool("", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_bool(xmp_ns::XMP, ""), None);
+    }
+
+    #[test]
+    fn invalid_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_bool("\0", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn invalid_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_bool(xmp_ns::XMP, "\0"), None);
+    }
+}
+
+mod property_i32 {
+    use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
+
+    #[test]
+    fn happy_path() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_i32(xmp_ns::EXIF, "PixelXDimension"),
+            Some(XmpValue {
+                value: 200,
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn unrecognizable_as_int() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32(xmp_ns::XMP, "CreatorTool"), None);
+    }
+
+    #[test]
+    fn bool_value() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32(xmp_ns::XMP_RIGHTS, "Marked"), None);
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32("", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32(xmp_ns::XMP, ""), None);
+    }
+
+    #[test]
+    fn invalid_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32("\0", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn invalid_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i32(xmp_ns::XMP, "\0"), None);
+    }
+}
+
+mod property_i64 {
+    use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
+
+    #[test]
+    fn happy_path() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_i64(xmp_ns::EXIF, "PixelXDimension"),
+            Some(XmpValue {
+                value: 200,
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn unrecognizable_as_int() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64(xmp_ns::XMP, "CreatorTool"), None);
+    }
+
+    #[test]
+    fn bool_value() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64(xmp_ns::XMP_RIGHTS, "Marked"), None);
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64("", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64(xmp_ns::XMP, ""), None);
+    }
+
+    #[test]
+    fn invalid_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64("\0", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn invalid_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_i64(xmp_ns::XMP, "\0"), None);
+    }
+}
+
+mod property_f64 {
+    use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
+
+    #[test]
+    fn happy_path() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_f64(xmp_ns::EXIF, "PixelXDimension"),
+            Some(XmpValue {
+                value: 200.0,
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn ratio() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64(xmp_ns::TIFF, "XResolution"), None);
+    }
+
+    #[test]
+    fn unrecognizable_as_float() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64(xmp_ns::XMP, "CreatorTool"), None);
+    }
+
+    #[test]
+    fn bool_value() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64(xmp_ns::XMP_RIGHTS, "Marked"), None);
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64("", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64(xmp_ns::XMP, ""), None);
+    }
+
+    #[test]
+    fn invalid_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64("\0", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn invalid_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_f64(xmp_ns::XMP, "\0"), None);
+    }
+}
+
+mod property_date {
+    use crate::{
+        tests::fixtures::*, xmp_ns, XmpDate, XmpDateTime, XmpMeta, XmpTime, XmpTimeZone, XmpValue,
+    };
+
+    #[test]
+    fn happy_path() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(
+            m.property_date(xmp_ns::XMP, "ModifyDate"),
+            Some(XmpValue {
+                value: XmpDateTime {
+                    date: Some(XmpDate {
+                        year: 2006,
+                        month: 4,
+                        day: 27
+                    }),
+                    time: Some(XmpTime {
+                        hour: 15,
+                        minute: 38,
+                        second: 36,
+                        nanosecond: 655000000,
+                        time_zone: Some(XmpTimeZone { hour: 2, minute: 0 }),
+                    })
+                },
+                options: 0
+            })
+        );
+    }
+
+    #[test]
+    fn unrecognizable_as_date() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date(xmp_ns::XMP, "CreatorTool"), None);
+    }
+
+    #[test]
+    fn bool_value() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date(xmp_ns::XMP_RIGHTS, "Marked"), None);
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date("", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date(xmp_ns::XMP, ""), None);
+    }
+
+    #[test]
+    fn invalid_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date("\0", "CreatorTool"), None);
+    }
+
+    #[test]
+    fn invalid_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert_eq!(m.property_date(xmp_ns::XMP, "\0"), None);
+    }
+}
+
 mod set_property {
     use crate::{tests::fixtures::*, xmp_value::xmp_prop, XmpErrorType, XmpMeta, XmpValue};
 

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -157,6 +157,215 @@ impl XmpMeta {
         }
     }
 
+    /// Gets a simple property value and interprets it as a bool.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `None` in such cases.
+    ///
+    /// If the value can not be parsed as a boolean (for example, it is
+    /// an unrecognizable string), the function will return `None`.
+    pub fn property_bool(&self, schema_ns: &str, prop_name: &str) -> Option<XmpValue<bool>> {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let mut options: u32 = 0;
+        let mut value = false;
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            if ffi::CXmpMetaGetProperty_Bool(
+                self.m,
+                &mut err,
+                c_ns.as_ptr(),
+                c_name.as_ptr(),
+                &mut value,
+                &mut options,
+            ) {
+                Some(XmpValue { value, options })
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Gets a simple property value and interprets it as a 32-bit integer.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `None` in such cases.
+    ///
+    /// If the value can not be parsed as a number, the function will
+    /// return `None`.
+    pub fn property_i32(&self, schema_ns: &str, prop_name: &str) -> Option<XmpValue<i32>> {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let mut options: u32 = 0;
+        let mut value: i32 = 0;
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            if ffi::CXmpMetaGetProperty_Int(
+                self.m,
+                &mut err,
+                c_ns.as_ptr(),
+                c_name.as_ptr(),
+                &mut value,
+                &mut options,
+            ) {
+                Some(XmpValue { value, options })
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Gets a simple property value and interprets it as a 64-bit integer.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `None` in such cases.
+    ///
+    /// If the value can not be parsed as a number, the function will
+    /// return `None`.
+    pub fn property_i64(&self, schema_ns: &str, prop_name: &str) -> Option<XmpValue<i64>> {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let mut options: u32 = 0;
+        let mut value: i64 = 0;
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            if ffi::CXmpMetaGetProperty_Int64(
+                self.m,
+                &mut err,
+                c_ns.as_ptr(),
+                c_name.as_ptr(),
+                &mut value,
+                &mut options,
+            ) {
+                Some(XmpValue { value, options })
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Gets a simple property value and interprets it as a 64-bit float.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `None` in such cases.
+    ///
+    /// If the value can not be parsed as a number, the function will
+    /// return `None`. Note that ratio values, such as those found in
+    /// TIFF and EXIF blocks, are not parsed.
+    pub fn property_f64(&self, schema_ns: &str, prop_name: &str) -> Option<XmpValue<f64>> {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let mut options: u32 = 0;
+        let mut value: f64 = 0.0;
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            if ffi::CXmpMetaGetProperty_Float(
+                self.m,
+                &mut err,
+                c_ns.as_ptr(),
+                c_name.as_ptr(),
+                &mut value,
+                &mut options,
+            ) {
+                Some(XmpValue { value, options })
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Gets a simple property value and interprets it as a date/time value.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `None` in such cases.
+    ///
+    /// If the value can not be parsed as a date (for example, it is
+    /// an unrecognizable string), the function will return `None`.
+    pub fn property_date(&self, schema_ns: &str, prop_name: &str) -> Option<XmpValue<XmpDateTime>> {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let mut options: u32 = 0;
+        let mut value = ffi::CXmpDateTime::default();
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            if ffi::CXmpMetaGetProperty_Date(
+                self.m,
+                &mut err,
+                c_ns.as_ptr(),
+                c_name.as_ptr(),
+                &mut value,
+                &mut options,
+            ) {
+                Some(XmpValue {
+                    value: XmpDateTime::from_ffi(&value),
+                    options,
+                })
+            } else {
+                None
+            }
+        }
+    }
+
     /// Creates or sets a property value.
     ///
     /// This is the simplest property setter. Use it for top-level


### PR DESCRIPTION
## Changes in this pull request
This adds typed property getters that use the underlying C++ code to parse property values as `bool`, `i32`, `i64`, `f64`, and `XmpDateTime` values.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
