### PR TITLE
(MINOR) Rename `XmpMeta.array_property` to `.property_array`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ xmp_toolkit = "0.6.0"
 
 ## Breaking changes in 0.x series
 
+### Upgrading to 0.7 from earlier versions
+
+The `XmpMeta::array_property` method has been renamed to `XmpMeta::property_array`
+to make it consistent with the other typed property getters.
+
 ### Upgrading to 0.6 from earlier versions
 
 The `XmpMeta::property` method has been changed to return `Option<XmpValue<String>>`

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -206,6 +206,56 @@ mod property {
     }
 }
 
+mod property_array {
+    use std::str::FromStr;
+
+    use crate::{tests::fixtures::*, XmpMeta, XmpValue};
+
+    #[test]
+    fn happy_path_creator_seq() {
+        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
+
+        let mut creators: Vec<XmpValue<String>> = m
+            .property_array("http://purl.org/dc/elements/1.1/", "creator")
+            .collect();
+
+        assert_eq!(creators.len(), 1);
+
+        let creator = creators.pop().unwrap();
+        assert_eq!(creator.value, "Llywelyn");
+        // assert_eq!(creator.options, 0);
+        // TO DO: Implement this test when options are exposed.
+    }
+
+    #[test]
+    fn happy_path_creator_bag() {
+        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
+
+        let mut subjects: Vec<String> = m
+            .property_array("http://purl.org/dc/elements/1.1/", "subject")
+            .map(|v| v.value)
+            .collect();
+
+        subjects.sort();
+
+        assert_eq!(
+            subjects,
+            vec!("Stefan", "XMP", "XMPFiles", "purple", "square", "test")
+        );
+    }
+
+    #[test]
+    fn no_such_property() {
+        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
+
+        let first_creator = m
+            .property_array("http://purl.org/dc/elements/1.1/", "creatorx")
+            .next();
+
+        assert!(first_creator.is_none());
+    }
+}
+
 mod property_bool {
     use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
 
@@ -967,55 +1017,5 @@ mod does_property_exist {
     fn empty_prop_name() {
         let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
         assert!(!m.does_property_exist(xmp_ns::XMP, ""));
-    }
-}
-
-mod array_property {
-    use std::str::FromStr;
-
-    use crate::{tests::fixtures::*, XmpMeta, XmpValue};
-
-    #[test]
-    fn happy_path_creator_seq() {
-        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
-
-        let mut creators: Vec<XmpValue<String>> = m
-            .array_property("http://purl.org/dc/elements/1.1/", "creator")
-            .collect();
-
-        assert_eq!(creators.len(), 1);
-
-        let creator = creators.pop().unwrap();
-        assert_eq!(creator.value, "Llywelyn");
-        // assert_eq!(creator.options, 0);
-        // TO DO: Implement this test when options are exposed.
-    }
-
-    #[test]
-    fn happy_path_creator_bag() {
-        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
-
-        let mut subjects: Vec<String> = m
-            .array_property("http://purl.org/dc/elements/1.1/", "subject")
-            .map(|v| v.value)
-            .collect();
-
-        subjects.sort();
-
-        assert_eq!(
-            subjects,
-            vec!("Stefan", "XMP", "XMPFiles", "purple", "square", "test")
-        );
-    }
-
-    #[test]
-    fn no_such_property() {
-        let m = XmpMeta::from_str(PURPLE_SQUARE_XMP).unwrap();
-
-        let first_creator = m
-            .array_property("http://purl.org/dc/elements/1.1/", "creatorx")
-            .next();
-
-        assert!(first_creator.is_none());
     }
 }

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -157,6 +157,24 @@ impl XmpMeta {
         }
     }
 
+    /// Creates an iterator for an array property value.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    pub fn property_array(&self, schema_ns: &str, prop_name: &str) -> ArrayProperty {
+        ArrayProperty {
+            meta: self,
+            ns: CString::new(schema_ns).unwrap_or_default(),
+            name: CString::new(prop_name).unwrap_or_default(),
+            index: 1,
+        }
+    }
+
     /// Gets a simple property value and interprets it as a bool.
     ///
     /// ## Arguments
@@ -595,24 +613,6 @@ impl XmpMeta {
         XmpError::raise_from_c(&err)
     }
 
-    /// Creates an iterator for an array property value.
-    ///
-    /// ## Arguments
-    ///
-    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
-    ///
-    /// * `prop_name`: The name of the property. Can be a general path
-    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
-    ///   for namespace prefix usage.
-    pub fn array_property(&self, schema_ns: &str, prop_name: &str) -> ArrayProperty {
-        ArrayProperty {
-            meta: self,
-            ns: CString::new(schema_ns).unwrap_or_default(),
-            name: CString::new(prop_name).unwrap_or_default(),
-            index: 1,
-        }
-    }
-
     /// Reports whether a property currently exists.
     ///
     /// ## Arguments
@@ -659,7 +659,7 @@ impl FromStr for XmpMeta {
 
 /// An iterator that provides access to items within a property array.
 ///
-/// Create via [`XmpMeta::array_property`].
+/// Create via [`XmpMeta::property_array`].
 pub struct ArrayProperty<'a> {
     meta: &'a XmpMeta,
     ns: CString,


### PR DESCRIPTION
## Changes in this pull request
This makes it consistent with the other typed property getters.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
