### PR TITLE
(MINOR) Rename `XmpMeta::does_property_exist` to `XmpMeta::contains_property`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ xmp_toolkit = "0.6.0"
 The `XmpMeta::array_property` method has been renamed to `XmpMeta::property_array`
 to make it consistent with the other typed property getters.
 
+The `XmpMeta::does_property_exist` method has been renamed to `XmpMeta::contains_property`
+for consistency with other Rust container types.
+
 ### Upgrading to 0.6 from earlier versions
 
 The `XmpMeta::property` method has been changed to return `Option<XmpValue<String>>`

--- a/src/tests/xmp_file.rs
+++ b/src/tests/xmp_file.rs
@@ -36,10 +36,10 @@ fn open_and_edit_file() {
         m.set_property("http://purl.org/dc/terms/", "provenance", &"blah".into())
             .unwrap();
 
-        assert!(m.does_property_exist("http://purl.org/dc/terms/", "provenance"));
-        assert!(!m.does_property_exist("http://purl.org/dc/terms/", "provenancx"));
+        assert!(m.contains_property("http://purl.org/dc/terms/", "provenance"));
+        assert!(!m.contains_property("http://purl.org/dc/terms/", "provenancx"));
 
-        if m.does_property_exist(xmp_ns::XMP, "MetadataDate") {
+        if m.contains_property(xmp_ns::XMP, "MetadataDate") {
             let updated_time = XmpDateTime::current().unwrap();
             m.set_property_date(xmp_ns::XMP, "MetadataDate", &updated_time.into())
                 .unwrap();

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -166,6 +166,34 @@ mod register_namespace {
     }
 }
 
+mod contains_property {
+    use crate::{tests::fixtures::*, xmp_ns, XmpMeta};
+
+    #[test]
+    fn exists() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert!(m.contains_property(xmp_ns::XMP, "CreatorTool"));
+    }
+
+    #[test]
+    fn doesnt_exist() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert!(!m.contains_property(xmp_ns::XMP, "RandomProperty"));
+    }
+
+    #[test]
+    fn empty_namespace() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert!(!m.contains_property("", "CreatorTool"));
+    }
+
+    #[test]
+    fn empty_prop_name() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        assert!(!m.contains_property(xmp_ns::XMP, ""));
+    }
+}
+
 mod property {
     use crate::{tests::fixtures::*, xmp_ns, XmpMeta, XmpValue};
 
@@ -989,33 +1017,5 @@ mod set_property_date {
             err.debug_message,
             "Unable to convert to C string because a NUL byte was found"
         );
-    }
-}
-
-mod does_property_exist {
-    use crate::{tests::fixtures::*, xmp_ns, XmpMeta};
-
-    #[test]
-    fn exists() {
-        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
-        assert!(m.does_property_exist(xmp_ns::XMP, "CreatorTool"));
-    }
-
-    #[test]
-    fn doesnt_exist() {
-        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
-        assert!(!m.does_property_exist(xmp_ns::XMP, "RandomProperty"));
-    }
-
-    #[test]
-    fn empty_namespace() {
-        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
-        assert!(!m.does_property_exist("", "CreatorTool"));
-    }
-
-    #[test]
-    fn empty_prop_name() {
-        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
-        assert!(!m.does_property_exist(xmp_ns::XMP, ""));
     }
 }

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -104,6 +104,28 @@ impl XmpMeta {
         }
     }
 
+    /// Returns `true` if the metadata block contains a property by this name.
+    ///
+    /// ## Arguments
+    ///
+    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
+    ///
+    /// * `prop_name`: The name of the property. Can be a general path
+    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
+    ///   for namespace prefix usage.
+    ///
+    /// ## Error handling
+    ///
+    /// Any errors (for instance, empty or invalid namespace or property name)
+    /// are ignored; the function will return `false` in such cases.
+    pub fn contains_property(&self, schema_ns: &str, prop_name: &str) -> bool {
+        let c_ns = CString::new(schema_ns).unwrap_or_default();
+        let c_name = CString::new(prop_name).unwrap_or_default();
+
+        let r = unsafe { ffi::CXmpMetaDoesPropertyExist(self.m, c_ns.as_ptr(), c_name.as_ptr()) };
+        r != 0
+    }
+
     /// Gets a simple string property value.
     ///
     /// When specifying a namespace and path (in this and all other accessors):
@@ -611,28 +633,6 @@ impl XmpMeta {
         }
 
         XmpError::raise_from_c(&err)
-    }
-
-    /// Reports whether a property currently exists.
-    ///
-    /// ## Arguments
-    ///
-    /// * `schema_ns`: The namespace URI; see [`XmpMeta::property()`].
-    ///
-    /// * `prop_name`: The name of the property. Can be a general path
-    ///   expression. Must not be an empty string. See [`XmpMeta::property()`]
-    ///   for namespace prefix usage.
-    ///
-    /// ## Error handling
-    ///
-    /// Any errors (for instance, empty or invalid namespace or property name)
-    /// are ignored; the function will return `false` in such cases.
-    pub fn does_property_exist(&self, schema_ns: &str, prop_name: &str) -> bool {
-        let c_ns = CString::new(schema_ns).unwrap_or_default();
-        let c_name = CString::new(prop_name).unwrap_or_default();
-
-        let r = unsafe { ffi::CXmpMetaDoesPropertyExist(self.m, c_ns.as_ptr(), c_name.as_ptr()) };
-        r != 0
     }
 }
 


### PR DESCRIPTION
## Changes in this pull request
This makes this API consistent with other Rust container types.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
