### PR TITLE
Implement `Display` for `XmpDateTime`

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -96,7 +96,7 @@ static void signalUnknownError(CXmpError* outError) {
 static bool xmpFileErrorCallback(void* context,
                                  XMP_StringPtr filePath,
                                  XMP_ErrorSeverity severity,
-                                 XMP_Int32 cause,
+                                 AdobeXMPCommon::int32 cause,
                                  XMP_StringPtr message) {
     CXmpError* err = (CXmpError*) context;
     if (err) {
@@ -684,5 +684,25 @@ extern "C" {
                 signalUnknownError(outError);
             }
         #endif
+    }
+
+    const char* CXmpDateTimeToString(const XMP_DateTime* dt, CXmpError* outError) {
+        #ifndef NOOP_FFI
+            try {
+                if (dt) {
+                    std::string dtAsString;
+                    SXMPUtils::ConvertFromDate(*dt, &dtAsString);
+                    return copyStringForResult(dtAsString);
+                }
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return NULL;
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -228,4 +228,10 @@ extern "C" {
     // --- CXmpDateTime ---
 
     pub(crate) fn CXmpDateTimeCurrent(dt: *mut CXmpDateTime, out_error: *mut CXmpError);
+
+    pub(crate) fn CXmpDateTimeToString(
+        dt: *const CXmpDateTime,
+        out_error: *mut CXmpError,
+    ) -> *mut c_char;
+
 }

--- a/src/tests/xmp_date_time.rs
+++ b/src/tests/xmp_date_time.rs
@@ -551,3 +551,178 @@ mod as_ffi {
         );
     }
 }
+
+mod fmt {
+    use crate::{XmpDate, XmpDateTime, XmpTime, XmpTimeZone};
+
+    #[test]
+    fn fully_populated_west_of_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: -7,
+                    minute: 0,
+                }),
+            }),
+        };
+
+        assert_eq!(format!("{}", dt), "2022-10-19T18:09:20.000000042-07:00");
+    }
+
+    #[test]
+    fn fully_populated_east_of_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: 5,
+                    minute: 30,
+                }),
+            }),
+        };
+
+        assert_eq!(format!("{}", dt), "2022-10-19T18:09:20.000000042+05:30");
+    }
+
+    #[test]
+    fn fully_populated_utc() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone { hour: 0, minute: 0 }),
+            }),
+        };
+
+        assert_eq!(format!("{}", dt), "2022-10-19T18:09:20.000000042Z");
+    }
+
+    #[test]
+    fn no_time_zone() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: None,
+            }),
+        };
+
+        assert_eq!(format!("{}", dt), "2022-10-19T18:09:20.000000042");
+    }
+
+    #[test]
+    fn no_time() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 2022,
+                month: 10,
+                day: 19,
+            }),
+            time: None,
+        };
+
+        assert_eq!(format!("{}", dt), "2022-10-19");
+    }
+
+    #[test]
+    fn no_time_year_after_10000() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 10203,
+                month: 10,
+                day: 19,
+            }),
+            time: None,
+        };
+
+        assert_eq!(format!("{}", dt), "10203-10-19");
+    }
+
+    #[test]
+    fn no_time_year_before_1000() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: 981,
+                month: 10,
+                day: 19,
+            }),
+            time: None,
+        };
+
+        assert_eq!(format!("{}", dt), "0981-10-19");
+    }
+
+    #[test]
+    fn no_time_year_before_0() {
+        let dt = XmpDateTime {
+            date: Some(XmpDate {
+                year: -542,
+                month: 10,
+                day: 19,
+            }),
+            time: None,
+        };
+
+        assert_eq!(format!("{}", dt), "-0542-10-19");
+    }
+
+    #[test]
+    fn no_date() {
+        let dt = XmpDateTime {
+            date: None,
+            time: Some(XmpTime {
+                hour: 18,
+                minute: 9,
+                second: 20,
+                nanosecond: 42,
+                time_zone: Some(XmpTimeZone {
+                    hour: -7,
+                    minute: 0,
+                }),
+            }),
+        };
+
+        assert_eq!(format!("{}", dt), "0000-01-01T18:09:20.000000042-07:00");
+    }
+
+    #[test]
+    fn no_date_or_time() {
+        let dt = XmpDateTime {
+            date: None,
+            time: None,
+        };
+
+        assert_eq!(format!("{}", dt), "0000");
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
This uses the C++ XMP Toolkit's rendering of date/time values to handle numerous edge cases.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
