### PR TITLE
Fix crash if `XmpMeta::debug_dump_namespaces` was the first call into XMP Toolkit

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -336,6 +336,8 @@ extern "C" {
 
     void CXmpDumpNamespaces(void* rustString, XMP_TextOutputProc callback) {
         #ifndef NOOP_FFI
+            init_xmp();
+
             try {
                 SXMPMeta::DumpNamespaces(callback, rustString);
             }


### PR DESCRIPTION
## Changes in this pull request
Add a call to initialize C++ XMP Toolkit at this point.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
