### PR TITLE
Impl `Debug` for `XmpMeta`

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -770,6 +770,19 @@ extern "C" {
         return NULL;
     }
 
+    void CXmpMetaDumpObj(CXmpMeta* m,
+                         void* rustString,
+                         XMP_TextOutputProc callback) {
+        #ifndef NOOP_FFI
+            try {
+                m->m.DumpObject(callback, rustString);
+            }
+            catch (...) {
+                // intentional no-op
+            }
+        #endif
+    }
+
     // --- CXmpDateTime ---
 
     void CXmpDateTimeCurrent(XMP_DateTime* dt, CXmpError* outError) {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -336,6 +336,12 @@ extern "C" {
         field_name: *const c_char,
     ) -> *const c_char;
 
+    pub(crate) fn CXmpMetaDumpObj(
+        meta: *mut CXmpMeta,
+        out_string: *mut c_void,
+        callback: CXmpTextOutputProc,
+    );
+
     // --- CXmpDateTime ---
 
     pub(crate) fn CXmpDateTimeCurrent(dt: *mut CXmpDateTime, out_error: *mut CXmpError);

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -1305,3 +1305,16 @@ mod compose_struct_field_path {
         );
     }
 }
+
+mod impl_debug {
+    use crate::{tests::fixtures::*, XmpMeta};
+
+    #[test]
+    fn fmt() {
+        let m = XmpMeta::from_file(fixture_path("Purple Square.psd")).unwrap();
+        let s = format!("{:#?}", m);
+
+        println!("Debug dump of XMP object follows:\n\n{}", s);
+        assert!(s.starts_with("XMPMeta object \"\""));
+    }
+}

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::{ffi::CString, os::raw::c_void, path::Path, str::FromStr};
+use std::{ffi::CString, fmt, os::raw::c_void, path::Path, str::FromStr};
 
 use crate::{
     ffi::{self, CXmpString},
@@ -838,6 +838,27 @@ impl XmpMeta {
             XmpError::raise_from_c(&err)?;
             Ok(result.as_string())
         }
+    }
+}
+
+impl fmt::Debug for XmpMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let mut result = String::default();
+
+        unsafe {
+            let result: *mut String = &mut result;
+            ffi::CXmpMetaDumpObj(
+                self.m,
+                std::mem::transmute::<*mut String, *mut c_void>(result),
+                ffi::xmp_dump_to_string,
+            );
+        }
+
+        if result.starts_with("Dumping ") {
+            result.replace_range(0..8, "");
+        }
+
+        write!(f, "{}", result)
     }
 }
 


### PR DESCRIPTION
## Changes in this pull request
Uses C++ XMP Toolkit's implementation of `XMP_Meta.DumpObject()`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
