### PR TITLE
Add `XmpMeta::name` and `XmpMeta::set_name` accessors

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -743,6 +743,41 @@ extern "C" {
         return NULL;
     }
 
+    const char* CXmpMetaGetObjectName(CXmpMeta* m, CXmpError* outError) {
+        #ifndef NOOP_FFI
+            try {
+                std::string name;
+                m->m.GetObjectName(&name);
+                return copyStringForResult(name);
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+
+        return NULL;
+    }
+
+    void CXmpMetaSetObjectName(CXmpMeta* m,
+                               CXmpError* outError,
+                               const char* name) {
+        #ifndef NOOP_FFI
+            try {
+                m->m.SetObjectName(name);
+            }
+            catch (XMP_Error& e) {
+                copyErrorForResult(e, outError);
+            }
+            catch (...) {
+                signalUnknownError(outError);
+            }
+        #endif
+    }
+
+
     const char* CXmpMetaComposeStructFieldPath(CXmpError* outError,
                                                const char* schemaNS,
                                                const char* structName,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -328,6 +328,17 @@ extern "C" {
         out_options: *mut u32,
     ) -> *const c_char;
 
+    pub(crate) fn CXmpMetaGetObjectName(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+    ) -> *const c_char;
+
+    pub(crate) fn CXmpMetaSetObjectName(
+        meta: *mut CXmpMeta,
+        out_error: *mut CXmpError,
+        name: *const c_char,
+    );
+
     pub(crate) fn CXmpMetaComposeStructFieldPath(
         out_error: *mut CXmpError,
         schema_ns: *const c_char,

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -1293,6 +1293,23 @@ mod localized_text {
     }
 }
 
+mod name {
+    use crate::XmpMeta;
+
+    #[test]
+    fn default() {
+        let m = XmpMeta::new().unwrap();
+        assert_eq!(m.name(), "");
+    }
+
+    #[test]
+    fn set() {
+        let mut m = XmpMeta::new().unwrap();
+        m.set_name("foo").unwrap();
+        assert_eq!(m.name(), "foo");
+    }
+}
+
 mod compose_struct_field_path {
     use crate::{xmp_ns, XmpMeta};
 

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -839,6 +839,34 @@ impl XmpMeta {
             Ok(result.as_string())
         }
     }
+
+    /// Returns the client-assigned name of this XMP object.
+    ///
+    /// This name is the empty string by default.
+    ///
+    /// See also `XmpMeta::set_name`.
+    pub fn name(&self) -> String {
+        let mut err = ffi::CXmpError::default();
+
+        unsafe { CXmpString::from_ptr(ffi::CXmpMetaGetObjectName(self.m, &mut err)).as_string() }
+    }
+
+    /// Assigns a name to this XMP object.
+    ///
+    /// This name can be retrieved via `XmpMeta::name`.
+    ///
+    /// This name is for client use only and it not interpreted by
+    /// the XMP Toolkit.
+    pub fn set_name(&mut self, name: &str) -> XmpResult<()> {
+        let c_name = CString::new(name.as_bytes())?;
+        let mut err = ffi::CXmpError::default();
+
+        unsafe {
+            ffi::CXmpMetaSetObjectName(self.m, &mut err, c_name.as_ptr());
+        }
+
+        XmpError::raise_from_c(&err)
+    }
 }
 
 impl fmt::Debug for XmpMeta {


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
