### PR TITLE
Implement `Default` for `XmpMeta`

### DIFF
--- a/src/tests/xmp_file.rs
+++ b/src/tests/xmp_file.rs
@@ -145,6 +145,22 @@ mod can_put_xmp {
 
         assert!(!f.can_put_xmp(&m));
     }
+
+    #[test]
+    fn init_fail() {
+        let tempdir = tempdir().unwrap();
+        let no_xmp = temp_copy_of_fixture(tempdir.path(), "no_xmp.txt");
+
+        let mut f = XmpFile::new().unwrap();
+        assert!(f
+            .open_file(&no_xmp, OpenFileOptions::default().for_update())
+            .is_ok());
+
+        XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
+
+        let m = XmpMeta::new_fail();
+        assert!(!f.can_put_xmp(&m));
+    }
 }
 
 mod put_xmp {
@@ -172,5 +188,23 @@ mod put_xmp {
 
         assert_eq!(err.error_type, XmpErrorType::Unavailable);
         assert_eq!(err.debug_message, "XMPFiles::PutXMP - Can't inject XMP");
+    }
+
+    #[test]
+    fn init_fail() {
+        let tempdir = tempdir().unwrap();
+        let no_xmp = temp_copy_of_fixture(tempdir.path(), "no_xmp.txt");
+
+        let mut f = XmpFile::new().unwrap();
+        assert!(f
+            .open_file(&no_xmp, OpenFileOptions::default().for_update())
+            .is_ok());
+
+        XmpMeta::register_namespace("http://purl.org/dc/terms/", "dcterms").unwrap();
+
+        let m = XmpMeta::new_fail();
+        let err = f.put_xmp(&m).unwrap_err();
+
+        assert_eq!(err.error_type, XmpErrorType::NoCppToolkit);
     }
 }

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -15,9 +15,14 @@ use crate::XmpMeta;
 
 #[test]
 fn new_empty() {
-    let mut _m = XmpMeta::new();
+    let m = XmpMeta::new().unwrap();
+    assert_eq!(format!("{:#?}", m), "XMPMeta object \"\"  (0x0)\n");
+}
 
-    // TODO: Add more tests when we can iterate.
+#[test]
+fn default() {
+    let m = XmpMeta::default();
+    assert_eq!(format!("{:#?}", m), "XMPMeta object \"\"  (0x0)\n");
 }
 
 mod from_file {

--- a/src/tests/xmp_meta.rs
+++ b/src/tests/xmp_meta.rs
@@ -377,11 +377,9 @@ mod property_array {
     fn init_fail() {
         let m = XmpMeta::new_fail();
 
-        let creators: Vec<XmpValue<String>> = m
-            .property_array("http://purl.org/dc/elements/1.1/", "creator")
-            .collect();
+        let mut creator_iter = m.property_array("http://purl.org/dc/elements/1.1/", "creator");
 
-        assert!(creators.is_empty());
+        assert!(creator_iter.next().is_none());
     }
 
     #[test]

--- a/src/xmp_error.rs
+++ b/src/xmp_error.rs
@@ -283,6 +283,10 @@ pub enum XmpErrorType {
     /// found.
     #[error("Unable to convert to C string because a NUL byte was found")]
     NulInRustString = -432,
+
+    /// C++ toolkit did not initialize properly.
+    #[error("C++ XMP toolkit did not initialize properly")]
+    NoCppToolkit = -433,
 }
 
 /// A specialized `Result` type for XMP Toolkit operations.

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -63,12 +63,19 @@ impl XmpMeta {
     /// An error result from this function is unlikely but possible
     /// if, for example, the C++ XMP Toolkit fails to initialize or
     /// reports an out-of-memory condition.
-    pub fn new() -> XmpResult<XmpMeta> {
+    pub fn new() -> XmpResult<Self> {
         let mut err = ffi::CXmpError::default();
         let m = unsafe { ffi::CXmpMetaNew(&mut err) };
         XmpError::raise_from_c(&err)?;
 
-        Ok(XmpMeta { m: Some(m) })
+        Ok(Self { m: Some(m) })
+    }
+
+    /// Use only for testing. Simulates failure to initialize
+    /// C++ XMP Toolkit.
+    #[allow(dead_code)] // used only in test code
+    pub(crate) fn new_fail() -> Self {
+        Self { m: None }
     }
 
     /// Reads the XMP from a file without keeping the file open.

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -44,13 +44,15 @@ use crate::{
 ///   expression can be a namespace prefix; if so, the prefix must have been
 ///   registered via [`XmpMeta::register_namespace`].
 pub struct XmpMeta {
-    pub(crate) m: *mut ffi::CXmpMeta,
+    pub(crate) m: Option<*mut ffi::CXmpMeta>,
 }
 
 impl Drop for XmpMeta {
     fn drop(&mut self) {
-        unsafe {
-            ffi::CXmpMetaDrop(self.m);
+        if let Some(m) = self.m {
+            unsafe {
+                ffi::CXmpMetaDrop(m);
+            }
         }
     }
 }
@@ -66,7 +68,7 @@ impl XmpMeta {
         let m = unsafe { ffi::CXmpMetaNew(&mut err) };
         XmpError::raise_from_c(&err)?;
 
-        Ok(XmpMeta { m })
+        Ok(XmpMeta { m: Some(m) })
     }
 
     /// Reads the XMP from a file without keeping the file open.
@@ -152,11 +154,15 @@ impl XmpMeta {
     /// Any errors (for instance, empty or invalid namespace or property name)
     /// are ignored; the function will return `false` in such cases.
     pub fn contains_property(&self, namespace: &str, path: &str) -> bool {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let r = unsafe { ffi::CXmpMetaDoesPropertyExist(self.m, c_ns.as_ptr(), c_name.as_ptr()) };
-        r != 0
+            let r = unsafe { ffi::CXmpMetaDoesPropertyExist(m, c_ns.as_ptr(), c_name.as_ptr()) };
+            r != 0
+        } else {
+            false
+        }
     }
 
     /// Returns `true` if the metadata block contains a struct field by this
@@ -180,22 +186,24 @@ impl XmpMeta {
         field_ns: &str,
         field_name: &str,
     ) -> bool {
-        let c_struct_ns = CString::new(struct_ns).unwrap_or_default();
-        let c_struct_name = CString::new(struct_path).unwrap_or_default();
-        let c_field_ns = CString::new(field_ns).unwrap_or_default();
-        let c_field_name = CString::new(field_name).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_struct_ns = CString::new(struct_ns).unwrap_or_default();
+            let c_struct_name = CString::new(struct_path).unwrap_or_default();
+            let c_field_ns = CString::new(field_ns).unwrap_or_default();
+            let c_field_name = CString::new(field_name).unwrap_or_default();
 
-        let r = unsafe {
-            ffi::CXmpMetaDoesStructFieldExist(
-                self.m,
-                c_struct_ns.as_ptr(),
-                c_struct_name.as_ptr(),
-                c_field_ns.as_ptr(),
-                c_field_name.as_ptr(),
-            )
-        };
-
-        r != 0
+            unsafe {
+                ffi::CXmpMetaDoesStructFieldExist(
+                    m,
+                    c_struct_ns.as_ptr(),
+                    c_struct_name.as_ptr(),
+                    c_field_ns.as_ptr(),
+                    c_field_name.as_ptr(),
+                ) != 0
+            }
+        } else {
+            false
+        }
     }
 
     /// Gets a simple string property value.
@@ -210,21 +218,25 @@ impl XmpMeta {
     /// Any errors (for instance, empty or invalid namespace or property name)
     /// are ignored; the function will return `None` in such cases.
     pub fn property(&self, namespace: &str, path: &str) -> Option<XmpValue<String>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            CXmpString::from_ptr(ffi::CXmpMetaGetProperty(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut options,
-            ))
-            .map(|value| XmpValue { value, options })
+            unsafe {
+                CXmpString::from_ptr(ffi::CXmpMetaGetProperty(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut options,
+                ))
+                .map(|value| XmpValue { value, options })
+            }
+        } else {
+            None
         }
     }
 
@@ -258,26 +270,30 @@ impl XmpMeta {
     /// If the value can not be parsed as a boolean (for example, it is
     /// an unrecognizable string), the function will return `None`.
     pub fn property_bool(&self, namespace: &str, path: &str) -> Option<XmpValue<bool>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut value = false;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut value = false;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            if ffi::CXmpMetaGetProperty_Bool(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut value,
-                &mut options,
-            ) {
-                Some(XmpValue { value, options })
-            } else {
-                None
+            unsafe {
+                if ffi::CXmpMetaGetProperty_Bool(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut value,
+                    &mut options,
+                ) {
+                    Some(XmpValue { value, options })
+                } else {
+                    None
+                }
             }
+        } else {
+            None
         }
     }
 
@@ -296,26 +312,30 @@ impl XmpMeta {
     /// If the value can not be parsed as a number, the function will
     /// return `None`.
     pub fn property_i32(&self, namespace: &str, path: &str) -> Option<XmpValue<i32>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut value: i32 = 0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut value: i32 = 0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            if ffi::CXmpMetaGetProperty_Int(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut value,
-                &mut options,
-            ) {
-                Some(XmpValue { value, options })
-            } else {
-                None
+            unsafe {
+                if ffi::CXmpMetaGetProperty_Int(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut value,
+                    &mut options,
+                ) {
+                    Some(XmpValue { value, options })
+                } else {
+                    None
+                }
             }
+        } else {
+            None
         }
     }
 
@@ -334,26 +354,30 @@ impl XmpMeta {
     /// If the value can not be parsed as a number, the function will
     /// return `None`.
     pub fn property_i64(&self, namespace: &str, path: &str) -> Option<XmpValue<i64>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut value: i64 = 0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut value: i64 = 0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            if ffi::CXmpMetaGetProperty_Int64(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut value,
-                &mut options,
-            ) {
-                Some(XmpValue { value, options })
-            } else {
-                None
+            unsafe {
+                if ffi::CXmpMetaGetProperty_Int64(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut value,
+                    &mut options,
+                ) {
+                    Some(XmpValue { value, options })
+                } else {
+                    None
+                }
             }
+        } else {
+            None
         }
     }
 
@@ -373,26 +397,30 @@ impl XmpMeta {
     /// return `None`. Note that ratio values, such as those found in
     /// TIFF and EXIF blocks, are not parsed.
     pub fn property_f64(&self, namespace: &str, path: &str) -> Option<XmpValue<f64>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut value: f64 = 0.0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut value: f64 = 0.0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            if ffi::CXmpMetaGetProperty_Float(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut value,
-                &mut options,
-            ) {
-                Some(XmpValue { value, options })
-            } else {
-                None
+            unsafe {
+                if ffi::CXmpMetaGetProperty_Float(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut value,
+                    &mut options,
+                ) {
+                    Some(XmpValue { value, options })
+                } else {
+                    None
+                }
             }
+        } else {
+            None
         }
     }
 
@@ -411,29 +439,33 @@ impl XmpMeta {
     /// If the value can not be parsed as a date (for example, it is
     /// an unrecognizable string), the function will return `None`.
     pub fn property_date(&self, namespace: &str, path: &str) -> Option<XmpValue<XmpDateTime>> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut value = ffi::CXmpDateTime::default();
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut value = ffi::CXmpDateTime::default();
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            if ffi::CXmpMetaGetProperty_Date(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &mut value,
-                &mut options,
-            ) {
-                Some(XmpValue {
-                    value: XmpDateTime::from_ffi(&value),
-                    options,
-                })
-            } else {
-                None
+            unsafe {
+                if ffi::CXmpMetaGetProperty_Date(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &mut value,
+                    &mut options,
+                ) {
+                    Some(XmpValue {
+                        value: XmpDateTime::from_ffi(&value),
+                        options,
+                    })
+                } else {
+                    None
+                }
             }
+        } else {
+            None
         }
     }
 
@@ -457,25 +489,29 @@ impl XmpMeta {
         field_ns: &str,
         field_name: &str,
     ) -> Option<XmpValue<String>> {
-        let c_struct_ns = CString::new(struct_ns).unwrap_or_default();
-        let c_struct_name = CString::new(struct_path).unwrap_or_default();
-        let c_field_ns = CString::new(field_ns).unwrap_or_default();
-        let c_field_name = CString::new(field_name).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_struct_ns = CString::new(struct_ns).unwrap_or_default();
+            let c_struct_name = CString::new(struct_path).unwrap_or_default();
+            let c_field_ns = CString::new(field_ns).unwrap_or_default();
+            let c_field_name = CString::new(field_name).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            CXmpString::from_ptr(ffi::CXmpMetaGetStructField(
-                self.m,
-                &mut err,
-                c_struct_ns.as_ptr(),
-                c_struct_name.as_ptr(),
-                c_field_ns.as_ptr(),
-                c_field_name.as_ptr(),
-                &mut options,
-            ))
-            .map(|value| XmpValue { value, options })
+            unsafe {
+                CXmpString::from_ptr(ffi::CXmpMetaGetStructField(
+                    m,
+                    &mut err,
+                    c_struct_ns.as_ptr(),
+                    c_struct_name.as_ptr(),
+                    c_field_ns.as_ptr(),
+                    c_field_name.as_ptr(),
+                    &mut options,
+                ))
+                .map(|value| XmpValue { value, options })
+            }
+        } else {
+            None
         }
     }
 
@@ -495,23 +531,27 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<String>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let c_value = CString::new(new_value.value.as_bytes())?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let c_value = CString::new(new_value.value.as_bytes())?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                c_value.as_ptr(),
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    c_value.as_ptr(),
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Creates or sets a property value using a bool value.
@@ -530,22 +570,26 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<bool>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty_Bool(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                new_value.value,
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty_Bool(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    new_value.value,
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Creates or sets a property value using a 32-bit integer value.
@@ -564,22 +608,26 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<i32>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty_Int(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                new_value.value,
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty_Int(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    new_value.value,
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Creates or sets a property value using a 64-bit integer value.
@@ -598,22 +646,26 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<i64>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty_Int64(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                new_value.value,
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty_Int64(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    new_value.value,
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Creates or sets a property value using a 64-bit floating-point value.
@@ -632,22 +684,26 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<f64>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty_Float(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                new_value.value,
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty_Float(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    new_value.value,
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Creates or sets a property value using an [`XmpDateTime`] structure.
@@ -666,22 +722,26 @@ impl XmpMeta {
         path: &str,
         new_value: &XmpValue<XmpDateTime>,
     ) -> XmpResult<()> {
-        let c_ns = CString::new(namespace)?;
-        let c_name = CString::new(path)?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace)?;
+            let c_name = CString::new(path)?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetProperty_Date(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                &new_value.value.as_ffi(),
-                new_value.options,
-            );
+            unsafe {
+                ffi::CXmpMetaSetProperty_Date(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    &new_value.value.as_ffi(),
+                    new_value.options,
+                );
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 
     /// Retrieves information about a selected item from an alt-text array.
@@ -767,36 +827,40 @@ impl XmpMeta {
         generic_lang: Option<&str>,
         specific_lang: &str,
     ) -> Option<(XmpValue<String>, String)> {
-        let c_ns = CString::new(namespace).unwrap_or_default();
-        let c_name = CString::new(path).unwrap_or_default();
-        let c_generic_lang = generic_lang.map(|s| CString::new(s).unwrap_or_default());
-        let c_specific_lang = CString::new(specific_lang).unwrap_or_default();
+        if let Some(m) = self.m {
+            let c_ns = CString::new(namespace).unwrap_or_default();
+            let c_name = CString::new(path).unwrap_or_default();
+            let c_generic_lang = generic_lang.map(|s| CString::new(s).unwrap_or_default());
+            let c_specific_lang = CString::new(specific_lang).unwrap_or_default();
 
-        let mut options: u32 = 0;
-        let mut err = ffi::CXmpError::default();
+            let mut options: u32 = 0;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            let mut c_actual_lang: *const i8 = std::ptr::null_mut();
+            unsafe {
+                let mut c_actual_lang: *const i8 = std::ptr::null_mut();
 
-            CXmpString::from_ptr(ffi::CXmpMetaGetLocalizedText(
-                self.m,
-                &mut err,
-                c_ns.as_ptr(),
-                c_name.as_ptr(),
-                match c_generic_lang {
-                    Some(p) => p.as_ptr(),
-                    None => std::ptr::null(),
-                },
-                c_specific_lang.as_ptr(),
-                &mut c_actual_lang,
-                &mut options,
-            ))
-            .map(|value| {
-                (
-                    XmpValue { value, options },
-                    CXmpString::from_ptr(c_actual_lang).as_string(),
-                )
-            })
+                CXmpString::from_ptr(ffi::CXmpMetaGetLocalizedText(
+                    m,
+                    &mut err,
+                    c_ns.as_ptr(),
+                    c_name.as_ptr(),
+                    match c_generic_lang {
+                        Some(p) => p.as_ptr(),
+                        None => std::ptr::null(),
+                    },
+                    c_specific_lang.as_ptr(),
+                    &mut c_actual_lang,
+                    &mut options,
+                ))
+                .map(|value| {
+                    (
+                        XmpValue { value, options },
+                        CXmpString::from_ptr(c_actual_lang).as_string(),
+                    )
+                })
+            }
+        } else {
+            None
         }
     }
 
@@ -846,9 +910,12 @@ impl XmpMeta {
     ///
     /// See also `XmpMeta::set_name`.
     pub fn name(&self) -> String {
-        let mut err = ffi::CXmpError::default();
-
-        unsafe { CXmpString::from_ptr(ffi::CXmpMetaGetObjectName(self.m, &mut err)).as_string() }
+        if let Some(m) = self.m {
+            let mut err = ffi::CXmpError::default();
+            unsafe { CXmpString::from_ptr(ffi::CXmpMetaGetObjectName(m, &mut err)).as_string() }
+        } else {
+            String::default()
+        }
     }
 
     /// Assigns a name to this XMP object.
@@ -858,35 +925,55 @@ impl XmpMeta {
     /// This name is for client use only and it not interpreted by
     /// the XMP Toolkit.
     pub fn set_name(&mut self, name: &str) -> XmpResult<()> {
-        let c_name = CString::new(name.as_bytes())?;
-        let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.m {
+            let c_name = CString::new(name.as_bytes())?;
+            let mut err = ffi::CXmpError::default();
 
-        unsafe {
-            ffi::CXmpMetaSetObjectName(self.m, &mut err, c_name.as_ptr());
+            unsafe {
+                ffi::CXmpMetaSetObjectName(m, &mut err, c_name.as_ptr());
+            }
+
+            XmpError::raise_from_c(&err)
+        } else {
+            Err(no_cpp_toolkit())
         }
-
-        XmpError::raise_from_c(&err)
     }
 }
 
 impl fmt::Debug for XmpMeta {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let mut result = String::default();
+        if let Some(m) = self.m {
+            let mut result = String::default();
 
-        unsafe {
-            let result: *mut String = &mut result;
-            ffi::CXmpMetaDumpObj(
-                self.m,
-                std::mem::transmute::<*mut String, *mut c_void>(result),
-                ffi::xmp_dump_to_string,
-            );
+            unsafe {
+                let result: *mut String = &mut result;
+                ffi::CXmpMetaDumpObj(
+                    m,
+                    std::mem::transmute::<*mut String, *mut c_void>(result),
+                    ffi::xmp_dump_to_string,
+                );
+            }
+
+            if result.starts_with("Dumping ") {
+                result.replace_range(0..8, "");
+            }
+
+            write!(f, "{}", result)
+        } else {
+            write!(f, "(C++ XMP Toolkit unavailable)")
         }
+    }
+}
 
-        if result.starts_with("Dumping ") {
-            result.replace_range(0..8, "");
+impl Default for XmpMeta {
+    fn default() -> Self {
+        let mut err = ffi::CXmpError::default();
+        let m = unsafe { ffi::CXmpMetaNew(&mut err) };
+        if m.is_null() {
+            XmpMeta { m: None }
+        } else {
+            XmpMeta { m: Some(m) }
         }
-
-        write!(f, "{}", result)
     }
 }
 
@@ -907,7 +994,7 @@ impl FromStr for XmpMeta {
             unsafe { ffi::CXmpMetaParseFromBuffer(&mut err, bytes.as_ptr(), bytes.len() as u32) };
         XmpError::raise_from_c(&err)?;
 
-        Ok(XmpMeta { m })
+        Ok(XmpMeta { m: Some(m) })
     }
 }
 
@@ -925,21 +1012,32 @@ impl<'a> Iterator for ArrayProperty<'a> {
     type Item = XmpValue<String>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        unsafe {
-            let mut options: u32 = 0;
-            let mut err = ffi::CXmpError::default();
+        if let Some(m) = self.meta.m {
+            unsafe {
+                let mut options: u32 = 0;
+                let mut err = ffi::CXmpError::default();
 
-            self.index += 1;
+                self.index += 1;
 
-            CXmpString::from_ptr(ffi::CXmpMetaGetArrayItem(
-                self.meta.m,
-                &mut err,
-                self.ns.as_ptr(),
-                self.name.as_ptr(),
-                self.index,
-                &mut options,
-            ))
-            .map(|value| XmpValue { value, options })
+                CXmpString::from_ptr(ffi::CXmpMetaGetArrayItem(
+                    m,
+                    &mut err,
+                    self.ns.as_ptr(),
+                    self.name.as_ptr(),
+                    self.index,
+                    &mut options,
+                ))
+                .map(|value| XmpValue { value, options })
+            }
+        } else {
+            None
         }
+    }
+}
+
+pub(crate) fn no_cpp_toolkit() -> XmpError {
+    XmpError {
+        error_type: XmpErrorType::NoCppToolkit,
+        debug_message: "C++ XMP Toolkit not available".to_owned(),
     }
 }


### PR DESCRIPTION
## Changes in this pull request
This implies that it needs to be safe for C++ XMP Toolkit initialization to fail. Add error handling for those cases.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
