### PR TITLE
(IGNORE) Fix CI failure immediately after release is prepared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,16 @@ jobs:
           major_pattern: "(MAJORXXXX)"
           minor_pattern: "(MINORXXXX)"
 
+      - name: Generate changelog since last tag
+        uses: mathiasvr/command-output@v1
+          ## NEEDS UPDATE for set-output deprecation.
+          ## See https://github.com/mathiasvr/command-output/issues/4.
+        id: changelog
+        with:
+          run: git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD || :; }
+
       - name: "Bump crate version (NOTE: Not pushed back to repo!)"
-        if: ${{ !contains(github.event.pull_request.title, '(MINOR)') }}
+        if: ${{ !contains(github.event.pull_request.title, '(MINOR)') && steps.changelog.outputs.stdout != '' }}
         run: |
           sed -i "s/^version = \"[^\"]*\"$/version = \"$VERSION\"/;" Cargo.toml
           git config user.email "nobody@example.com"
@@ -267,14 +275,14 @@ jobs:
         uses: mathiasvr/command-output@v1
         continue-on-error: true
         id: bump_exists
-        if: ${{ !contains(github.event.pull_request.title, '(MINOR)') }}
+        if: ${{ !contains(github.event.pull_request.title, '(MINOR)') && steps.changelog.outputs.stdout != '' }}
         with:
           run: |
             git log --format="%s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD | grep "(MINOR)"
 
       - name: If this step fails, change title of the PR to include (MINOR) tag
         uses: obi1kenobi/cargo-semver-checks-action@v1
-        if: ${{ steps.bump_exists.outputs.stdout == '' && (!github.event.pull_request.title || !contains(github.event.pull_request.title, '(MINOR)')) }}
+        if: ${{ steps.bump_exists.outputs.stdout == '' && (!github.event.pull_request.title || !contains(github.event.pull_request.title, '(MINOR)')) && steps.changelog.outputs.stdout != '' }}
         with:
           crate-name: xmp_toolkit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           ## See https://github.com/mathiasvr/command-output/issues/4.
         id: changelog
         with:
-          run: git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD || :; }
+          run: git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD
 
       - name: "Bump crate version (NOTE: Not pushed back to repo!)"
         if: ${{ !contains(github.event.pull_request.title, '(MINOR)') && steps.changelog.outputs.stdout != '' }}


### PR DESCRIPTION
## Changes in this pull request
CI fails when re-checking `main` after a release is prepared. Turns out git doesn't like to commit an empty change.

Bypass (MINOR) version checks when there are no commits after most recent tag.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
