### PR TITLE
(IGNORE) Use CodeCov upload token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Upload code coverage results
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 


### PR DESCRIPTION
Per recommendation in [upload issues thread](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954), using an upload token despite it being a public repo.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
