### PR TITLE
(MAJOR) Prepare for stable API (1.0) release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,7 @@ jobs:
           args: --all-targets --all-features
 
   version_bump:
-    name: Ensure (MINOR) tag is used when making an API breaking change
-    # Change all of these steps to (MAJOR) after 1.0 release
+    name: Ensure (MAJOR) tag is used when making an API breaking change
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -270,7 +269,7 @@ jobs:
         env:
           VERSION: ${{ steps.set-version.outputs.version }}
 
-      - name: If this step fails, change title of the PR to include (MINOR) tag
+      - name: If this step fails, change title of the PR to include (MAJOR) tag
         uses: obi1kenobi/cargo-semver-checks-action@v1
         with:
           crate-name: xmp_toolkit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,6 @@ jobs:
       with:
         body: ${{ steps.changelog.outputs.stdout }}
         commit: ${{ steps.commit.outputs.commit_hash }}
-        prerelease: true # remove at 1.0
         tag: ${{ steps.set-version.outputs.version_tag }}
         token: ${{ secrets.GH_ADMIN_COMMIT_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,13 @@ The toolkit has been tested on the following operating systems:
 
 This crate incorporates the June 2022 version of the C++ [Adobe XMP Toolkit SDK](https://github.com/adobe/XMP-Toolkit-SDK/).
 
-When a newer version of the C++ XMP Toolkit is incorporated, a new minor (0.x.0) version of this crate will be released.
+When a newer version of the C++ XMP Toolkit is incorporated, a new minor (1.x.0) version of this crate will be released.
 
 ## Upgrading from earlier versions
 
-**This version of the crate is a 1.0 release candidate (discussion PR to follow).**
+This API is considered to to be stable; in other words, no further breaking changes are anticipated. For instructions on how to upgrade from various 0.x versions to 1.x, see the [Upgrading guide](./UPGRADING.md).
 
-This API is considered to to be stable; in other words, no further breaking changes are anticipated. For instructions on how to upgrade from various 0.x versions to the current version, see the [Upgrading guide](./UPGRADING.md).
-
-Minor, non-breaking additions to the API surface may be added as the few remaining APIs in the `XMP_Meta`, `XMP_Files`, `TXMPUtils` interfaces are exposed. Such changes will trigger minor (0.x.0) version increments when they happen.
+Minor, non-breaking additions to the API surface may be added as the few remaining APIs in the `XMP_Meta`, `XMP_Files`, `TXMPUtils` interfaces are exposed. Such changes will trigger minor (1.x.0) version increments when they happen.
 
 ### Usage
 


### PR DESCRIPTION
**I believe that this crate is ready for API stabilization.**

I'm seeking discussion regarding committing to the existing API as a stable interface over the next month. Barring unresolved feedback, this PR will be merged on 5 December 2022 and a 1.0 release issued at that time.

Between now and then, I welcome feedback on any issues or concerns that should block or delay a 1.0 release. Please review this crate and remaining APIs from the underlying C++ XMP Toolkit with an eye toward what might cause breaking API changes.

I believe the following are _not_ in scope for 1.0 release:

* Porting remaining APIs from `XMP_Meta`, `XMP_Files`, and `TXMPUtils`. (There are relatively few left and these may be added in 1.x releases.)
* Porting UTF-16 or UTF-32 APIs.
* Porting other APIs (notably the `I___` API surface).

Please either file issues here in GitHub or add comments to this PR while discussion is open.