### PR TITLE
Don't call exit(1) if unable to initialize C++ XMP Toolkit

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -28,12 +28,10 @@ static volatile bool xmp_init_succeeded = false;
 
 inline void init_xmp_fn() {
     #ifndef NOOP_FFI
-        // TO DO (#100): Check return status from Initialize functions
-        // and eliminate call to exit(1).
         try {
-            // SXMPMeta::Initialize();
-            // SXMPFiles::Initialize(kXMPFiles_IgnoreLocalText);
-            // xmp_init_succeeded = true;
+            SXMPMeta::Initialize();
+            SXMPFiles::Initialize(kXMPFiles_IgnoreLocalText);
+            xmp_init_succeeded = true;
         }
         catch (XMP_Error& e) {
             fprintf(stderr, "Failed to initialize XMP Toolkit: %s\n", e.GetErrMsg());

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -24,24 +24,26 @@
 #endif
 
 std::once_flag xmp_init_flag;
+static volatile bool xmp_init_succeeded = false;
 
 inline void init_xmp_fn() {
     #ifndef NOOP_FFI
         // TO DO (#100): Check return status from Initialize functions
         // and eliminate call to exit(1).
         try {
-            SXMPMeta::Initialize();
-            SXMPFiles::Initialize(kXMPFiles_IgnoreLocalText);
+            // SXMPMeta::Initialize();
+            // SXMPFiles::Initialize(kXMPFiles_IgnoreLocalText);
+            // xmp_init_succeeded = true;
         }
         catch (XMP_Error& e) {
             fprintf(stderr, "Failed to initialize XMP Toolkit: %s\n", e.GetErrMsg());
-            exit(1);
         }
     #endif
 }
 
-static void init_xmp() {
+static bool init_xmp() {
     std::call_once(xmp_init_flag, init_xmp_fn);
+    return xmp_init_succeeded;
 }
 
 static const char* copyStringForResult(const std::string& result) {
@@ -93,6 +95,15 @@ static void signalUnknownError(CXmpError* outError) {
         outError->id = kXMPErr_Unknown;
         free((void*) outError->debugMessage);
         outError->debugMessage = NULL;
+    }
+}
+
+static void signalXmpInitFailure(CXmpError* outError) {
+    if (outError) {
+        outError->hadError = 1;
+        outError->id = kXMPErr_Unknown;
+        free((void*) outError->debugMessage);
+        outError->debugMessage = copyStringForResult("XMP Toolkit unavailable");
     }
 }
 
@@ -164,7 +175,10 @@ extern "C" {
 
     CXmpFile* CXmpFileNew(CXmpError* outError) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
             try {
                 return new CXmpFile;
             }
@@ -275,7 +289,10 @@ extern "C" {
 
     CXmpMeta* CXmpMetaNew(CXmpError* outError) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
             try {
                 return new CXmpMeta;
             }
@@ -320,7 +337,10 @@ extern "C" {
                                       AdobeXMPCommon::uint32 buffer_size,
                                       AdobeXMPCommon::uint32 options) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
             CXmpMeta* result = new CXmpMeta;
 
             try {
@@ -348,7 +368,10 @@ extern "C" {
                                           const char* indent,
                                           AdobeXMPCommon::uint32 baseIndent) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
 
             try {
                 std::string buffer;
@@ -370,7 +393,10 @@ extern "C" {
                                           const char* namespaceURI,
                                           const char* suggestedPrefix) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
 
             try {
                 std::string registeredPrefix;
@@ -392,7 +418,10 @@ extern "C" {
     const char* CXmpMetaGetNamespacePrefix(CXmpError* outError,
                                            const char* namespaceURI) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
 
             try {
                 std::string outPrefix;
@@ -414,7 +443,10 @@ extern "C" {
     const char* CXmpMetaGetNamespaceURI(CXmpError* outError,
                                         const char* namespacePrefix) {
         #ifndef NOOP_FFI
-            init_xmp();
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
 
             try {
                 std::string outURI;
@@ -435,13 +467,13 @@ extern "C" {
 
     void CXmpDumpNamespaces(void* rustString, XMP_TextOutputProc callback) {
         #ifndef NOOP_FFI
-            init_xmp();
-
-            try {
-                SXMPMeta::DumpNamespaces(callback, rustString);
-            }
-            catch (...) {
-                // intentional no-op
+            if (init_xmp()) {
+                try {
+                    SXMPMeta::DumpNamespaces(callback, rustString);
+                }
+                catch (...) {
+                    // intentional no-op
+                }
             }
         #endif
     }
@@ -1145,6 +1177,11 @@ extern "C" {
                                              const char* arrayName,
                                              AdobeXMPCommon::int32 index) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 std::string resultPath;
                 SXMPUtils::ComposeArrayItemPath(schemaNS,
@@ -1170,6 +1207,11 @@ extern "C" {
                                             const char* arrayName,
                                             const char* langName) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 std::string resultPath;
                 SXMPUtils::ComposeLangSelector(schemaNS,
@@ -1197,6 +1239,11 @@ extern "C" {
                                              const char* fieldName,
                                              const char* fieldValue) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 std::string resultPath;
                 SXMPUtils::ComposeFieldSelector(schemaNS,
@@ -1225,6 +1272,11 @@ extern "C" {
                                              const char* qualNS,
                                              const char* qualName) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 std::string resultPath;
                 SXMPUtils::ComposeQualifierPath(schemaNS,
@@ -1252,6 +1304,11 @@ extern "C" {
                                                const char* fieldNS,
                                                const char* fieldName) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 std::string resultPath;
                 SXMPUtils::ComposeStructFieldPath(schemaNS,
@@ -1385,10 +1442,15 @@ extern "C" {
 
     void CXmpDateTimeSetTimeZone(XMP_DateTime* dt, CXmpError* outError) {
         #ifndef NOOP_FFI
-        try {
-            if (dt) {
-                SXMPUtils::SetTimeZone(dt);
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return;
             }
+
+            try {
+                if (dt) {
+                    SXMPUtils::SetTimeZone(dt);
+                }
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);
@@ -1401,10 +1463,15 @@ extern "C" {
 
     void CXmpDateTimeConvertToLocalTime(XMP_DateTime* dt, CXmpError* outError) {
         #ifndef NOOP_FFI
-        try {
-            if (dt) {
-                SXMPUtils::ConvertToLocalTime(dt);
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return;
             }
+
+            try {
+                if (dt) {
+                    SXMPUtils::ConvertToLocalTime(dt);
+                }
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);
@@ -1417,10 +1484,15 @@ extern "C" {
 
     void CXmpDateTimeConvertToUTCTime(XMP_DateTime* dt, CXmpError* outError) {
         #ifndef NOOP_FFI
-        try {
-            if (dt) {
-                SXMPUtils::ConvertToUTCTime(dt);
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return;
             }
+
+            try {
+                if (dt) {
+                    SXMPUtils::ConvertToUTCTime(dt);
+                }
             }
             catch (XMP_Error& e) {
                 copyErrorForResult(e, outError);
@@ -1433,6 +1505,11 @@ extern "C" {
 
     const char* CXmpDateTimeToString(const XMP_DateTime* dt, CXmpError* outError) {
         #ifndef NOOP_FFI
+            if (!init_xmp()) {
+                signalXmpInitFailure(outError);
+                return NULL;
+            }
+
             try {
                 if (dt) {
                     std::string dtAsString;


### PR DESCRIPTION
## Changes in this pull request
If C++ XMP Toolkit fails, all calls to Rust XMP Toolkit APIs will fail with `Error::InternalFailure`, but the program will no longer self-terminate by calling `exit(1)`. Fixes #100.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
