### PR TITLE
Fix aarch64 compilation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,36 @@ jobs:
           # args: --all-targets --all-features (waiting on bug fix)
           args: --all-features
 
+  cross-build:
+    name: Cross build
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-unknown-linux-gnu]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run cross build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --all-targets --all-features --target ${{ matrix.target }}
+
   publish-preflight:
     name: Preflight crate publish
     runs-on: ${{ matrix.os }}

--- a/src/xmp_iterator.rs
+++ b/src/xmp_iterator.rs
@@ -12,6 +12,7 @@
 // each license.
 
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 use crate::{
     ffi::{self, CXmpString},
@@ -91,9 +92,9 @@ impl<'a> Iterator for XmpIterator<'a> {
         if !self.i.is_null() {
             unsafe {
                 let mut err = ffi::CXmpError::default();
-                let mut c_schema_ns: *const i8 = std::ptr::null_mut();
-                let mut c_prop_path: *const i8 = std::ptr::null_mut();
-                let mut c_prop_value: *const i8 = std::ptr::null_mut();
+                let mut c_schema_ns: *const c_char = std::ptr::null_mut();
+                let mut c_prop_path: *const c_char = std::ptr::null_mut();
+                let mut c_prop_value: *const c_char = std::ptr::null_mut();
                 let mut options: u32 = 0;
 
                 if ffi::CXmpIteratorNext(

--- a/src/xmp_iterator.rs
+++ b/src/xmp_iterator.rs
@@ -11,8 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::ffi::CString;
-use std::os::raw::c_char;
+use std::{ffi::CString, os::raw::c_char};
 
 use crate::{
     ffi::{self, CXmpString},

--- a/src/xmp_meta.rs
+++ b/src/xmp_meta.rs
@@ -11,7 +11,13 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use std::{ffi::CString, fmt, os::raw::c_void, path::Path, str::FromStr};
+use std::{
+    ffi::CString,
+    fmt,
+    os::raw::{c_char, c_void},
+    path::Path,
+    str::FromStr,
+};
 
 use crate::{
     ffi::{self, CXmpString},
@@ -1423,7 +1429,7 @@ impl XmpMeta {
             let mut err = ffi::CXmpError::default();
 
             unsafe {
-                let mut c_actual_lang: *const i8 = std::ptr::null_mut();
+                let mut c_actual_lang: *const c_char = std::ptr::null_mut();
 
                 CXmpString::from_ptr(ffi::CXmpMetaGetLocalizedText(
                     m,


### PR DESCRIPTION
## Changes in this pull request
Changes some specific variables from an `i8` to a `c_char`, since the functions that use these variables take `c_char`s as input.
This is specifically an issue when trying to cross compile for aarch64, since `c_char` is defined as a `u8` for that architecture.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
