### PR TITLE
Added option for static CRT using /MT flag (thanks @spector-9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 chrono = ["dep:chrono"]
+crt_static = []
 
 [dependencies]
 chrono = { version = "0.4.24", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -62,6 +62,9 @@ fn main() {
                 .include("external/xmp_toolkit/XMPCore/resource/win")
                 .include("external/xmp_toolkit/XMPFiles/resource/win");
 
+            if cfg!(feature = "crt_static") {
+                xmp_config.static_crt(true);
+            }
             xmp_config
                 .define("WIN_ENV", "1")
                 .define("XMP_WinBuild", "1")


### PR DESCRIPTION
## Changes in this pull request
Some libraries might have conflict if they are using /MT and this crate uses /MD flag or vice versa for linking the runtime on Windows. So this just add a simple feature flag to change the runtime to static using /MT if required.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
