### PR TITLE
(IGNORE) Remove "Check for unknown features in cfg attributes and macros" CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,21 +250,6 @@ jobs:
           version: latest
           args: --all-targets --all-features
 
-  unknown-features-cfg:
-    name: Check for unknown features in cfg attributes and macros
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Check for unknown features
-        env:
-          RUSTFLAGS: "-D unexpected-cfgs"
-        run: cargo +nightly check -Z unstable-options -Z check-cfg=features --tests
-
   version_bump:
     name: Ensure (MAJOR) tag is used when making an API breaking change
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nightly build changed in an incompatible way :-(
