### PR TITLE
Fix Mac build: Add '-stdlib=libc++'

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -106,6 +106,7 @@ fn main() {
                 .define("XMP_MacBuild", "1")
                 .define("_LARGEFILE64_SOURCE", None)
                 .define("XML_DEV_URANDOM", None)
+                .flag("-stdlib=libc++")
                 .flag("-Wno-deprecated-declarations")
                 .flag("-Wno-deprecated-register")
                 .flag("-Wno-int-in-bool-context")


### PR DESCRIPTION
Issue seems to appear only in recent GitHub Mac build environment; can not repro locally