### PR TITLE
Fix compilation of libexpat with latest cc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,7 @@ num_enum = "0.7.0"
 thiserror = "1.0"
 
 [build-dependencies]
-cc = "> 1.0.60, <=1.0.83"
-    # IMPORTANT: We can not upgrade to 1.0.86 or later until
-    # https://github.com/adobe/xmp-toolkit-rs/issues/197 is resolved.
-    # If someone has time to address that issue before we get to it,
-    # a PR would be very welcome.
-
+cc = { version = "1", features = ["parallel"] }
 fs_extra = "1.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num_enum = "0.7.0"
 thiserror = "1.0"
 
 [build-dependencies]
-cc = { version = "1", features = ["parallel"] }
+cc = { version = ">= 1.0.86", features = ["parallel"] }
 fs_extra = "1.3"
 
 [dev-dependencies]


### PR DESCRIPTION
## Changes in this pull request
- Use compile_intermediates from cc crate to compile libexpat (and update cc ) 
    - #197 
    - #211
- Copy third-party items to $OUT_DIR so the manifest dir can remain untouched 
    - which comes with the benefit of being able to use read-only vendored source 
    - as well as being able to use `nix` build system for dependent crates

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
