### PR TITLE
Publish workflow can now run cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Dry-run of crate publish
-        run: cargo publish --no-verify -p xmp_toolkit --dry-run
+        run: cargo publish -p xmp_toolkit --dry-run
 
   clippy_check:
     name: Clippy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,6 @@ jobs:
 
     - name: Publish crate
       run: |
-        cargo publish --no-verify --token $CRATES_IO_SECRET
+        cargo publish --token $CRATES_IO_SECRET
       env:
         CRATES_IO_SECRET: ${{ secrets.CRATES_IO_SECRET }}

--- a/build.rs
+++ b/build.rs
@@ -351,6 +351,7 @@ fn copy_external_to_third_party(from_path: &str, to_path: &str) {
     src_path.push("external");
     src_path.push(from_path);
 
+    eprintln!("Copying external lib from {}", src_path.display());
     assert!(src_path.is_dir());
 
     dest_path.pop();

--- a/build.rs
+++ b/build.rs
@@ -351,7 +351,7 @@ fn copy_external_to_third_party(from_path: &str, to_path: &str) {
     src_path.push("external");
     src_path.push(from_path);
 
-    eprintln!("Copying external lib from {}", src_path.display());
+    dbg!(&src_path);
     assert!(src_path.is_dir());
 
     dest_path.pop();

--- a/build.rs
+++ b/build.rs
@@ -34,11 +34,6 @@ fn main() {
         eprintln!("INFO: building standard FFI for crate");
     }
 
-    // Special note: Because of the post-processing we're doing here,
-    // you must specify the `--no-verify` option when invoking `cargo publish`.
-    // This is unfortunately necessary because the original XMP Toolkit requires
-    // the modified versions of these files to be present in these locations.
-
     copy_external_to_third_party("libexpat/expat/lib", "expat/lib");
 
     let mut zlib_adler_c_path = env::current_dir().unwrap();


### PR DESCRIPTION
Remove --no-verify flag. (Yay!)
