### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Since version 1.9.1, the format of this changelog is based on [Keep a Changelog]
 
 Do not manually edit this file. It will be automatically updated when a new release is published.
 
+## [1.9.1](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.0...v1.9.1)
+_30 August 2024_
+
+### Fixed
+* Start using [release-plz](https://release-plz.ieni.dev) to manage releases
+
+### Other
+* Prevent publishing by using a nonsense token
+* Populate git submodules before running release-plz
+* Adjust release-plz config to use existing crates.io token
+* Use a PAT to grant access to release-plz for triggering further actions
+* Trigger CI on PR updates
+* Remove version bump check. Should now be covered by release-plz
+* Remove Cargo.toml call-out
+* Tweak changelog body format
+* Update EmbarkStudios/cargo-deny-action action to v2 ([#236](https://github.com/adobe/xmp-toolkit-rs/pull/236))
+
 ## 1.9.0
 _26 July 2024_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,6 @@ _30 August 2024_
 * Start using [release-plz](https://release-plz.ieni.dev) to manage releases
 
 ### Other
-* Prevent publishing by using a nonsense token
-* Populate git submodules before running release-plz
-* Adjust release-plz config to use existing crates.io token
-* Use a PAT to grant access to release-plz for triggering further actions
-* Trigger CI on PR updates
-* Remove version bump check. Should now be covered by release-plz
-* Remove Cargo.toml call-out
-* Tweak changelog body format
 * Update EmbarkStudios/cargo-deny-action action to v2 ([#236](https://github.com/adobe/xmp-toolkit-rs/pull/236))
 
 ## 1.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmp_toolkit"
-version = "1.9.0"
+version = "1.9.1"
 description = "Rust-language bindings for Adobe's XMP Toolkit"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/adobe/xmp-toolkit-rs"


### PR DESCRIPTION
## 🤖 New release
* `xmp_toolkit`: 1.9.0 -> 1.9.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.9.1](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.0...v1.9.1)

_30 August 2024_

### Fixed
* Start using [release-plz](https://release-plz.ieni.dev) to manage releases

### Other
* Prevent publishing by using a nonsense token
* Populate git submodules before running release-plz
* Adjust release-plz config to use existing crates.io token
* Use a PAT to grant access to release-plz for triggering further actions
* Trigger CI on PR updates
* Remove version bump check. Should now be covered by release-plz
* Remove Cargo.toml call-out
* Tweak changelog body format
* Update EmbarkStudios/cargo-deny-action action to v2 ([#236](https://github.com/adobe/xmp-toolkit-rs/pull/236))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).