### PR TITLE
chore: release v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Since version 1.9.1, the format of this changelog is based on [Keep a Changelog]
 
 Do not manually edit this file. It will be automatically updated when a new release is published.
 
+## [1.9.2](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.1...v1.9.2)
+_28 September 2024_
+
+### Other
+* Update exception pattern for Dependabot, not Renovate
+* Disable Renovate
+* Add exception for Dependabot update PR title pattern
+* Introduce `update` commit type
+* Check PR title for Conventional Commits syntax
+
 ## [1.9.1](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.0...v1.9.1)
 _30 August 2024_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmp_toolkit"
-version = "1.9.1"
+version = "1.9.2"
 description = "Rust-language bindings for Adobe's XMP Toolkit"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/adobe/xmp-toolkit-rs"


### PR DESCRIPTION
## 🤖 New release
* `xmp_toolkit`: 1.9.1 -> 1.9.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.9.2](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.1...v1.9.2)

_28 September 2024_

### Other
* Update exception pattern for Dependabot, not Renovate
* Disable Renovate
* Add exception for Dependabot update PR title pattern
* Introduce `update` commit type
* Check PR title for Conventional Commits syntax
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).