### PR TITLE
fix: Omit redefinition of fdopen on MacOS

### DIFF
--- a/external/zlib/zutil.h
+++ b/external/zlib/zutil.h
@@ -144,7 +144,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #      include <unix.h> /* for fdopen */
 #    else
 #      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
+// #        define fdopen(fd,mode) NULL /* No fdopen() */
 #      endif
 #    endif
 #  endif


### PR DESCRIPTION
## Changes in this pull request
Omits redefinition of `fdopen` in `zutil.h` to get around a (most likely) macro expansion bug introduced in clang 17.0 (Xcode 16.3).

Fixes #259 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
