### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Since version 1.9.1, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.10.0](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.2...v1.10.0)
+_30 April 2025_
+
+### Added
+
+* Bump MSRV to 1.81.0 ([#261](https://github.com/adobe/xmp-toolkit-rs/pull/261))
+
+
+### Fixed
+
+* Omit redefinition of fdopen on macos ([#260](https://github.com/adobe/xmp-toolkit-rs/pull/260))
+
+### Other
+
+* Update rand requirement from 0.8.5 to 0.9.1 ([#257](https://github.com/adobe/xmp-toolkit-rs/pull/257))
+
 ## [1.9.2](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.1...v1.9.2)
 _12 December 2024_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ _30 April 2025_
 
 * Bump MSRV to 1.81.0 ([#261](https://github.com/adobe/xmp-toolkit-rs/pull/261))
 
-
 ### Fixed
 
 * Omit redefinition of fdopen on macos ([#260](https://github.com/adobe/xmp-toolkit-rs/pull/260))
@@ -24,7 +23,6 @@ _30 April 2025_
 
 ## [1.9.2](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.1...v1.9.2)
 _12 December 2024_
-
 
 ### Other
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmp_toolkit"
-version = "1.9.2"
+version = "1.10.0"
 description = "Rust-language bindings for Adobe's XMP Toolkit"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/adobe/xmp-toolkit-rs"


### PR DESCRIPTION



## 🤖 New release

* `xmp_toolkit`: 1.9.2 -> 1.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.10.0](https://github.com/adobe/xmp-toolkit-rs/compare/v1.9.2...v1.10.0)

_30 April 2025_

### Added

* Bump MSRV to 1.81.0 ([#261](https://github.com/adobe/xmp-toolkit-rs/pull/261))


### Fixed

* Omit redefinition of fdopen on macos ([#260](https://github.com/adobe/xmp-toolkit-rs/pull/260))

### Other

* Update rand requirement from 0.8.5 to 0.9.1 ([#257](https://github.com/adobe/xmp-toolkit-rs/pull/257))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).